### PR TITLE
run name through input_name method in select_tag method of mvc_form_help...

### DIFF
--- a/core/helpers/mvc_form_helper.php
+++ b/core/helpers/mvc_form_helper.php
@@ -140,7 +140,7 @@ class MvcFormHelper extends MvcHelper {
 		
 		$options = array_merge($defaults, $options);
 		$options['options'] = empty($options['options']) ? array() : $options['options'];
-		$options['name'] = $field_name;
+		$options['name'] = $this->input_name($field_name);
 		$attributes_html = self::attributes_html($options, 'select');
 		$html = '<select'.$attributes_html.'>';
 		if ($options['empty']) {


### PR DESCRIPTION
...er so select tag value is passed on form submit

Currently calling $this->form->select from an admin view creates a select with a name attribute exactly as passed in the method call, which is consequently not stored when form is submitted.

running $options['name'] through MvcFormHelper::input_name takes care of this.