### PR TITLE
set server vars to prevent wp from trying to redirect during cli calls r...

### DIFF
--- a/core/wpmvc.php
+++ b/core/wpmvc.php
@@ -3,6 +3,13 @@
 $wordpress_path = getenv('WPMVC_WORDPRESS_PATH');
 $wordpress_path = $wordpress_path ? rtrim($wordpress_path, '/').'/' : dirname(__FILE__).'/../../../../';
 
+$_SERVER = array(
+    "HTTP_HOST" => "localhost",
+    "SERVER_NAME" => "localhost",
+    "REQUEST_URI" => "/",
+    "REQUEST_METHOD" => "GET"
+);
+
 require_once $wordpress_path.'wp-load.php';
 
 $shell = new MvcShellDispatcher($argv);


### PR DESCRIPTION
...esulting in  silent failure. see http://vocecommunications.com/blog/2011/03/running-wordpress-from-command-line/

Without these server vars being set WP attempts to redirect and causes silent failure of any cli usage (WP 3.3.2)

Only tested on localhost, but should still be applicable when run on a remote host via SSH.