### PR TITLE
set default label to MvcInflector::titleize($fieldname) in MvcFormHelper...

### DIFF
--- a/core/helpers/mvc_form_helper.php
+++ b/core/helpers/mvc_form_helper.php
@@ -126,6 +126,10 @@ class MvcFormHelper extends MvcHelper {
 	}
 	
 	public function select($field_name, $options=array()) {
+		$defaults = array(
+			'label' => MvcInflector::titleize($field_name)
+		);
+		$options = array_merge($defaults, $options);
 		$html = $this->before_input($field_name, $options);
 		$html .= $this->select_tag($field_name, $options);
 		$html .= $this->after_input($field_name, $options);


### PR DESCRIPTION
...::select

Without actually passing a select tag through the general input method, some code ends up duplicated, although it's minimal. 

I believe this combined with my other pull regarding the select should put the select tag on par with the others for use in admin views.

btw if you choose to pull any of these, my wordpress.org handle is beezeee should you choose to list me as contributor in the readme :)