### PR TITLE
Add bundle dependencies param to plugin generator

### DIFF
--- a/core/shells/generate_shell.php
+++ b/core/shells/generate_shell.php
@@ -123,7 +123,7 @@ class GenerateShell extends MvcShell {
 		$this->templater->create('plugin', $target_path, $vars);
 		
 		$target_path = $plugin_path.$plugin_underscored.'_loader.php';
-		$this->templater->create('plugin_loader', $target_path, $vars, $bundle);
+		$this->templater->create('plugin_loader', $target_path, $vars);
 		if ($wpmvcBundleDependencies == 'bundleDependencies') {
 			mkdir($plugin_path.'wpmvc');
 			$this->recurse_copy(dirname(dirname(dirname(__FILE__))), $plugin_path.'wpmvc/');

--- a/core/templates/plugin/plugin.php
+++ b/core/templates/plugin/plugin.php
@@ -4,9 +4,13 @@ Plugin Name: <?php echo $name_titleized."\n"; ?>
 Plugin URI: 
 Description: 
 Author: 
-Version: 
+Version:
 Author URI: 
 */
+
+<?php global $wpmvcBundleDependencies; if ($wpmvcBundleDependencies == 'bundleDependencies'): ?>
+if (!defined('MVC_PLUGIN_PATH')) require_once(dirname(__FILE__).'/wpmvc/wp_mvc.php');
+<?php endif; ?>
 
 register_activation_hook(__FILE__, '<?php echo $name_underscored; ?>_activate');
 register_deactivation_hook(__FILE__, '<?php echo $name_underscored; ?>_deactivate');


### PR DESCRIPTION
it's kind of crude (just throwing the whole plugin in there and requiring if MVC_PLUGIN_PATH is not defined, but it seemed like the safe bet and looks to be working from a quick glance.

There certainly might be a more graceful way to achieve this, but I figured if nothing else it's a start and some food for thought.