### PR TITLE
fixed bug related to form helper in PHP 5.4

### DIFF
--- a/core/controllers/mvc_controller.php
+++ b/core/controllers/mvc_controller.php
@@ -106,7 +106,7 @@ class MvcController {
 			$this->{$helper_method_name} = new $helper_name();
 		
 			if ($helper_name == 'FormHelper') {
-				$this->{$helper_method_name}->controller = false;
+				$this->{$helper_method_name}->controller = new stdClass();
 				$this->{$helper_method_name}->controller->action = $this->action;
 				$this->{$helper_method_name}->controller->name = $this->name;
 			}


### PR DESCRIPTION
I was using this code in a project that I previously had worked on with an older version of PHP. I upgraded to 5.4 and noticed this error on a page using the form helper:

```php
Warning: Creating default object from empty value in ...\wp-mvc\core\controllers\mvc_controller.php on line 110
```

I traced the problem to that line of code assigning a value to a boolean value as if it were an object. So I changed line 109 from this:

```php
$this->{$helper_method_name}->controller = false;
```

to this:

```php
$this->{$helper_method_name}->controller = new stdClass();
```