### PR TITLE
Solved bug on url router when wordpress is installed inside a subfolder.

### DIFF
--- a/core/mvc_router.php
+++ b/core/mvc_router.php
@@ -26,7 +26,7 @@ class MvcRouter {
 			}
 			$model = MvcModelRegistry::get_model($model_name);
 			if (!empty($model) && method_exists($model, 'to_url')) {
-				$url = site_url('/');
+				$url = home_url('/');
 				$method = new ReflectionMethod(get_class($model), 'to_url');
 				$parameter_count = $method->getNumberOfParameters();
 				if ($parameter_count == 2) {
@@ -49,7 +49,7 @@ class MvcRouter {
 				}
 			}
 		}
-		$url = site_url('/');
+		$url = home_url('/');
 		if ($matched_route) {
 			$path_pattern = $matched_route[0];
 			preg_match_all('/{:([\w]+).*?}/', $path_pattern, $matches, PREG_SET_ORDER);


### PR DESCRIPTION
Wordpress sites installed inside a subfolder on the server, had wrong generated urls from the router. The router did not take the subfolder into account, and added it to the url when it should not have to. This resulted in a HTTP 404 error.
This problem is solved by using home_url() instead of site_url()