### PR TITLE
Fixed bug in PHP 5.4 and customize the links in admin list (index.php)

### DIFF
--- a/core/controllers/mvc_controller.php
+++ b/core/controllers/mvc_controller.php
@@ -106,7 +106,7 @@ class MvcController {
 			$this->{$helper_method_name} = new $helper_name();
 		
 			if ($helper_name == 'FormHelper') {
-				$this->{$helper_method_name}->controller = false;
+				$this->{$helper_method_name}->controller = new stdClass();
 				$this->{$helper_method_name}->controller->action = $this->action;
 				$this->{$helper_method_name}->controller->name = $this->name;
 			}

--- a/core/helpers/mvc_helper.php
+++ b/core/helpers/mvc_helper.php
@@ -198,9 +198,26 @@ class MvcHelper {
 		$links = array();
 		$object_name = empty($object->__name) ? 'Item #'.$object->__id : $object->__name;
 		$encoded_object_name = $this->esc_attr($object_name);
-		$links[] = '<a href="'.MvcRouter::admin_url(array('object' => $object, 'action' => 'edit')).'" title="Edit '.$encoded_object_name.'">Edit</a>';
-		$links[] = '<a href="'.MvcRouter::public_url(array('object' => $object)).'" title="View '.$encoded_object_name.'">View</a>';
-		$links[] = '<a href="'.MvcRouter::admin_url(array('object' => $object, 'action' => 'delete')).'" title="Delete '.$encoded_object_name.'" onclick="return confirm(&#039;Are you sure you want to delete '.$encoded_object_name.'?&#039;);">Delete</a>';
+		
+		//Customize the links
+		$links = array();
+		if(isset($controller->links_list) && is_array($controller->links_list) && count($controller->links_list) > 0) {
+			foreach($controller->links_list as $link) {
+				if(isset($link['level']) && strtolower($link['level']) == 'admin')
+					$href = MvcRouter::admin_url(array('object' => $object, 'action' => $link['action']));
+				else
+					$href = MvcRouter::public_url(array('object' => $object, 'action' => $link['action']));
+				
+				//Atribute
+				$params = isset($link['params']) ? $link['params'] : '';
+				$links[] = '<a href="'.$href.'" title="'.$link['label'].' '.$encoded_object_name.'"'.$params.'>'.$link['label'].'</a>';
+			}
+		}
+		else {
+			$links[] = '<a href="'.MvcRouter::admin_url(array('object' => $object, 'action' => 'edit')).'" title="Edit '.$encoded_object_name.'">Edit</a>';
+			$links[] = '<a href="'.MvcRouter::public_url(array('object' => $object)).'" title="View '.$encoded_object_name.'">View</a>';
+			$links[] = '<a href="'.MvcRouter::admin_url(array('object' => $object, 'action' => 'delete')).'" title="Delete '.$encoded_object_name.'" onclick="return confirm(&#039;Are you sure you want to delete '.$encoded_object_name.'?&#039;);">Delete</a>';
+		}
 		$html = implode(' | ', $links);
 		return '<td>'.$html.'</td>';
 	}

--- a/core/loaders/mvc_admin_loader.php
+++ b/core/loaders/mvc_admin_loader.php
@@ -67,6 +67,9 @@ class MvcAdminLoader extends MvcLoader {
 		// MvcConfiguration::append(array(
 		//   'PluginAdminRoleOrCapabilities' => array(
 		//     'speakers' => 'edit_posts'
+		//   ),
+		//   'AdminPages' => array(
+		//        'checks' => array('label' => 'Checks', 'capability' => 'check'),
 		//   )
 		// ));
 		// if no role/capability is set default role will be set to administrator

--- a/core/loaders/mvc_admin_loader.php
+++ b/core/loaders/mvc_admin_loader.php
@@ -61,8 +61,25 @@ class MvcAdminLoader extends MvcLoader {
 		
 		$admin_pages = MvcConfiguration::get('AdminPages');
 		
+		// Add this to your plugin's bootstrap file to grant
+		// users access to controllers based on role/capability.
+		// e.g:
+		// MvcConfiguration::append(array(
+		//   'PluginAdminRoleOrCapabilities' => array(
+		//     'speakers' => 'edit_posts'
+		//   )
+		// ));
+		// if no role/capability is set default role will be set to administrator
+		$plugin_admin_role_or_capabilities = MvcConfiguration::get('PluginAdminRoleOrCapabilities');
+
 		foreach ($this->admin_controller_names as $controller_name) {
 		
+			if (!isset($plugin_admin_role_or_capabilities) || empty($plugin_admin_role_or_capabilities[$controller_name])) {
+				$plugin_admin_role_or_capability = 'administrator';
+			} else {
+				$plugin_admin_role_or_capability = $plugin_admin_role_or_capabilities[$controller_name];
+			}
+			
 			if (isset($admin_pages[$controller_name])) {
 				if (empty($admin_pages[$controller_name]) || !$admin_pages[$controller_name]) {
 					continue;
@@ -89,7 +106,7 @@ class MvcAdminLoader extends MvcLoader {
 				add_menu_page(
 					$controller_titleized,
 					$controller_titleized,
-					'administrator',
+					$plugin_admin_role_or_capability,
 					$top_level_handle,
 					array($this->dispatcher, $method),
 					null,


### PR DESCRIPTION
To use, create a public property of the controller like this:
public $links_list = array(
							array('level' => 'admin', 'action' => 'export', 'label' => 'Exportar'),
							array('level' => 'admin', 'action' => 'delete', 'label' => 'Apagar', 'params' => 'onclick="return confirm(\'Tem certeza?\');"')
						 );