### PR TITLE
removed hard-coded menu_position

### DIFF
--- a/core/loaders/mvc_admin_loader.php
+++ b/core/loaders/mvc_admin_loader.php
@@ -93,7 +93,7 @@ class MvcAdminLoader extends MvcLoader {
 					$top_level_handle,
 					array($this->dispatcher, $method),
 					null,
-					$menu_position
+					null //$menu_position
 				);
 			
 				foreach ($processed_pages as $key => $admin_page) {


### PR DESCRIPTION
this affected other menus created by theme/plugins since the hard-coded position of 12 would overwrite anything that was "auto-generated" or "managed" by wordpress