### PR TITLE
Added support for custom dashicons, resolved issue #69

### DIFF
--- a/core/loaders/mvc_admin_loader.php
+++ b/core/loaders/mvc_admin_loader.php
@@ -80,23 +80,36 @@ class MvcAdminLoader extends MvcLoader {
             $hide_menu = isset($pages['hide_menu']) ? $pages['hide_menu'] : false;
             
             if (!$hide_menu) {
-                
+
+                $menu_icon = 'dashicons-admin-generic'; 
+                /* check if there is a corresponding model with a menu_icon post type argument */
+                try {
+                    $model_name = MvcInflector::singularize(MvcInflector::camelize($controller_name));
+                    $model = mvc_model($model_name);
+                    if(isset($model->wp_post['post_type']['args']['menu_icon'])) {
+                        $menu_icon = $model->wp_post['post_type']['args']['menu_icon'];    
+                    }
+                } catch (Exception $e) {
+                    ; //not every controller must have a corresponding model, continue silently
+                }
+
                 $controller_titleized = MvcInflector::titleize($controller_name);
         
                 $admin_controller_name = 'admin_'.$controller_name;
             
                 $top_level_handle = 'mvc_'.$controller_name;
+
             
                 $method = $admin_controller_name.'_index';
                 $this->dispatcher->{$method} = create_function('', 'MvcDispatcher::dispatch(array("controller" => "'.$admin_controller_name.'", "action" => "index"));');
-                        $capability = $this->admin_controller_capabilities[ $controller_name ];
+                $capability = $this->admin_controller_capabilities[ $controller_name ];
                 add_menu_page(
                     $controller_titleized,
                     $controller_titleized,
                     $capability,
                     $top_level_handle,
                     array($this->dispatcher, $method),
-                    null,
+                    $menu_icon,
                     $menu_position
                 );
             

--- a/core/loaders/mvc_public_loader.php
+++ b/core/loaders/mvc_public_loader.php
@@ -6,7 +6,9 @@ class MvcPublicLoader extends MvcLoader {
 
     public function flush_rewrite_rules($rules = array()) {
         global $wp_rewrite;
-        $wp_rewrite->flush_rules(false);
+        if (is_object($wp_rewrite)) {
+            $wp_rewrite->flush_rules(false);
+        }
     }
 
     public function load_rewrite_rules() {

--- a/core/models/wp_models/mvc_post_adapter.php
+++ b/core/models/wp_models/mvc_post_adapter.php
@@ -123,7 +123,8 @@ ALTER TABLE '.$model->table.' ADD INDEX (post_id);
                 'show_in_menu' => false,
                 'show_in_nav_menus' => true,
                 'hierarchical' => false,
-                'supports' => array('title', 'editor')
+                'supports' => array('title', 'editor'),
+                'menu_icon' => 'dashicons-admin-generic'
             );
             $args = is_array($settings['post_type']['args']) ? $settings['post_type']['args'] : array();
             $args = array_merge($default_args, $args);

--- a/examples/events-calendar-example/app/models/speaker.php
+++ b/examples/events-calendar-example/app/models/speaker.php
@@ -7,6 +7,9 @@ class Speaker extends MvcModel {
     var $has_many = array('Event');
     var $wp_post = array(
         'post_type' => array(
+            'args' => array(
+                'menu_icon' => 'dashicons-businessman'
+            ),
             'fields' => array(
                 'post_content' => '$description'
             )

--- a/examples/events-calendar-example/app/models/venue.php
+++ b/examples/events-calendar-example/app/models/venue.php
@@ -6,7 +6,7 @@ class Venue extends MvcModel {
     var $display_field = 'name';
     var $has_many = array('Event');
     var $wp_post = array(
-        'post_type' => true
+        'post_type' => true,
     );
     
     public function after_save($object) {

--- a/examples/events-calendar-example/events_calendar_example_loader.php
+++ b/examples/events-calendar-example/events_calendar_example_loader.php
@@ -62,7 +62,9 @@ class EventsCalendarExampleLoader extends MvcPluginLoader {
               last_name varchar(255) default NULL,
               url varchar(255) default NULL,
               description text,
-              PRIMARY KEY  (id)
+              post_id BIGINT(20),
+              PRIMARY KEY  (id),
+              KEY post_id (post_id)
             )';
         dbDelta($sql);
     
@@ -78,7 +80,9 @@ class EventsCalendarExampleLoader extends MvcPluginLoader {
               city varchar(100) default NULL,
               state varchar(100) default NULL,
               zip varchar(20) default NULL,
-              PRIMARY KEY  (id)
+              post_id BIGINT(20),
+              PRIMARY KEY  (id),
+              KEY post_id (post_id)
             )';
         dbDelta($sql);
         


### PR DESCRIPTION
Configure the model's `$wp_post['post_type']['args']['menu_icon']` value to a valid [Dashicon](https://developer.wordpress.org/resource/dashicons/#admin-home) name to customise the icon in use in the admin menu.