### PR TITLE
Add support for password field in Form Helper

### DIFF
--- a/core/helpers/mvc_form_helper.php
+++ b/core/helpers/mvc_form_helper.php
@@ -125,6 +125,20 @@ class MvcFormHelper extends MvcHelper {
         return $html;
     }
     
+    public function password_input($field_name, $options=array()) {
+        $defaults = array(
+            'id' => $this->input_id($field_name),
+            'name' => $this->input_name($field_name),
+            'type' => 'password'
+        );
+        $options = array_merge($defaults, $options);
+        $attributes_html = self::attributes_html($options, 'input');
+        $html = $this->before_input($field_name, $options);
+        $html .= '<input'.$attributes_html.' />';
+        $html .= $this->after_input($field_name, $options);
+        return $html;
+    }
+    
     public function select($field_name, $options=array()) {
         $html = $this->before_input($field_name, $options);
         $html .= $this->select_tag($field_name, $options);


### PR DESCRIPTION
As suggested in issue https://github.com/tombenner/wp-mvc/issues/76 I added a new method in `MvcFormHelper` to support password fields