### PR TITLE
allows to set join type and allows more than one join on the same table

### DIFF
--- a/core/functions/functions.php
+++ b/core/functions/functions.php
@@ -15,12 +15,12 @@ function mvc_plugin_app_url($plugin) {
 function mvc_model($model_name) {
     $model_underscore = MvcInflector::underscore($model_name);
     $file_includer = new MvcFileIncluder();
-    $file_includer->require_first_app_file('models/'.$model_underscore.'.php');
+    $file_includer->include_first_app_file('models/'.$model_underscore.'.php');
     if (class_exists($model_name)) {
         return new $model_name();
     }
-    MvcError::warning('Unable to load the "'.$model_name.'" model.');
-    return null;
+
+    throw new Exception('Unable to load the "'.$model_name.'" model.');
 }
 
 function mvc_setting($settings_name, $setting_key) {

--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -528,10 +528,9 @@ class MvcModel {
                     if (empty($association['fields'])) {
                         $association['fields'] = array($association['name'].'.*');
                     }
-                    $model = MvcModelRegistry::get_model($association['class']);/* todo: geändert*/
+                    $model = MvcModelRegistry::get_model($association['class']);
                     switch ($association['type']) {
                         case 'belongs_to':
-                        	//print_r($model_name);die;
                             $associated_object = $model->find_by_id($object->{$association['foreign_key']}, array(
                                 'recursive' => $recursive
                             ));

--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -338,7 +338,7 @@ class MvcModel {
         $result = $this->db_adapter->get_var($sql);
         return $result;
     }
-    
+
     protected function process_find_options($options) {
         if (!empty($options['joins'])) {
             if (is_string($options['joins'])) {
@@ -346,48 +346,61 @@ class MvcModel {
             }
             foreach ($options['joins'] as $key => $join) {
                 if (is_string($join)) {
-                    $join_model_name = $join;
-                    if (!empty($this->associations[$join_model_name])) {
-                        $association = $this->associations[$join_model_name];
-                        
-                        $join_model = new $join_model_name();
-                        
-                        switch ($association['type']) {
-                            case 'belongs_to':
-                                $join = array(
-                                    'table' => $join_model->table,
-                                    'on' => $join_model_name.'.'.$join_model->primary_key.' = '.$this->name.'.'.$association['foreign_key'],
-                                    'alias' => $join_model_name
-                                );
-                                break;
-                                
-                            case 'has_many':
-                                // To do: test this
-                                $join = array(
-                                    'table' => $this->table,
-                                    'on' => $join_model_name.'.'.$association['foreign_key'].' = '.$this->name.'.'.$this->primary_key,
-                                    'alias' => $join_model_name
-                                );
-                                break;
-                            
-                            case 'has_and_belongs_to_many':
-                                $join_table_alias = $join_model_name.$this->name;
-                                // The join for the HABTM join table
-                                $join = array(
-                                    'table' => $this->process_table_name($association['join_table']),
-                                    'on' => $join_table_alias.'.'.$association['foreign_key'].' = '.$this->name.'.'.$this->primary_key,
-                                    'alias' => $join_table_alias
-                                );
-                                // The join for the association model's table
-                                $second_join = array(
-                                    'table' => $join_model->table,
-                                    'on' => $join_table_alias.'.'.$association['association_foreign_key'].' = '.$join_model_name.'.'.$join_model->primary_key,
-                                    'alias' => $join_model_name
-                                );
-                                $options['joins'][] = $second_join;
-                                break;
-                        }
-                    }
+					$join_name = $join;
+					$join_model_name = $join;
+					$join_type = 'JOIN';
+				} else {
+					$join_name = $key;
+					$join_model_name = isset($join['class']) ? $join['class'] : $key;
+					$join_type  = isset($join['type']) ? $join['type'] : 'JOIN';
+				}
+
+				if (!empty($this->associations[$join_name])) {
+					$association = $this->associations[$join_name];
+
+					$join_model = new $join_model_name();
+
+					switch ($association['type']) {
+						case 'belongs_to':
+							$join = array(
+								'table' => $join_model->table,
+								'on' => $join_name.'.'.$join_model->primary_key.' = '.$this->name.'.'.$association['foreign_key'],
+								'alias' => $join_name,
+								'type' => $join_type
+							);
+
+							break;
+
+						case 'has_many':
+							$join = array(
+								'table' => $join_model->table,
+								'on' => $join_name.'.'.$association['foreign_key'].' = '.$this->name.'.'.$this->primary_key,
+								'alias' => $join_name,
+								'type' => $join_type
+							);
+
+							break;
+
+						case 'has_and_belongs_to_many':
+							$join_table_alias = $join_model_name.$this->name;
+							// The join for the HABTM join table
+							$join = array(
+								'table' => $this->process_table_name($association['join_table']),
+								'on' => $join_table_alias.'.'.$association['foreign_key'].' = '.$this->name.'.'.$this->primary_key,
+								'alias' => $join_table_alias,
+								'type' => $join_type
+							);
+							// The join for the association model's table
+							$second_join = array(
+								'table' => $join_model->table,
+								'on' => $join_table_alias.'.'.$association['association_foreign_key'].' = '.$join_model_name.'.'.$join_model->primary_key,
+								'alias' => $join_model_name,
+								'type' => $join_type
+							);
+							$options['joins'][] = $second_join;
+							break;
+					}
+
                     $options['joins'][$key] = $join;
                 }
             }
@@ -515,9 +528,10 @@ class MvcModel {
                     if (empty($association['fields'])) {
                         $association['fields'] = array($association['name'].'.*');
                     }
-                    $model = MvcModelRegistry::get_model($model_name);
+                    $model = MvcModelRegistry::get_model($association['class']);/* todo: geändert*/
                     switch ($association['type']) {
                         case 'belongs_to':
+                        	//print_r($model_name);die;
                             $associated_object = $model->find_by_id($object->{$association['foreign_key']}, array(
                                 'recursive' => $recursive
                             ));


### PR DESCRIPTION
It wasn't posible to connect / join / include one table with more than one field. this code will change that.

Table Example:
TgbJob.owner_id => foreign key => TgbUser.id
TgbJob.worker_id => foreign key => TgbUser.id

Config Example:
```php
  var $has_many = array(
    'TgbJobOwner' => array(
      'name' => 'TgbJob',
      'class' => 'TgbJob',
      'foreign_key' => 'owner_id'
    ),
    'TgbJobWorker' => array(
      'name' => 'TgbJob',
      'class' => 'TgbJob',
      'foreign_key' => 'worker_id'
    )
  );
```
also added the missing part to set the join type.

Config Example:
```php
  $this->params['joins'] = array(
    'TgbJobOwner' => array(
      'class' => 'TgbJob',
      'type' => 'LEFT JOIN',
    ),
    'TgbJobWorker' => array(
      'class' => 'TgbJob',
      'type' => 'LEFT JOIN',
    ),
  );
```