### PR TITLE
Fixes invalid argument warning for foreach() in mvc_public_loader.php

### DIFF
--- a/core/loaders/mvc_public_loader.php
+++ b/core/loaders/mvc_public_loader.php
@@ -118,9 +118,11 @@ class MvcPublicLoader extends MvcLoader {
     {
         $vars = array();
         $params = MvcConfiguration::get('RouteParams');
-        foreach($params as $param){
-            $param = 'mvc_' . $param;
-            $vars[] = $param;
+        if ( isset( $params ) ) {
+            foreach($params as $param){
+                $param = 'mvc_' . $param;
+                $vars[] = $param;
+            }
         }
 
         return $vars;


### PR DESCRIPTION
MvcConfiguration::get('RouteParams') will return null if there are no user defined route parameters which leads to a warning for "Invalid argument supplied for foreach()" for mvc_public_loader.php (line 121)