### PR TITLE
Fix: model->get_total_count() retuns wrong value when using options['…

### DIFF
--- a/core/controllers/mvc_public_controller.php
+++ b/core/controllers/mvc_public_controller.php
@@ -36,6 +36,9 @@ class MvcPublicController extends MvcController {
             'current' => $collection['page'],
             'add_args' => $params
         );
+        
+        unset($collection['objects']);
+        $this->pagination = array_merge($collection, $this->pagination);
     }
     
     public function pagination($options=array()) {

--- a/core/helpers/mvc_form_helper.php
+++ b/core/helpers/mvc_form_helper.php
@@ -18,11 +18,13 @@ class MvcFormHelper extends MvcHelper {
         if ($object_id) {
             $router_options['id'] = $object_id;
         }
-
-        $enctype = isset($options['enctype']) ? ' enctype="'.$options['enctype'].'"' : '';
-        $url = $options['public'] ? MvcRouter::public_url($router_options) : MvcRouter::admin_url($router_options);
-        $html = '<form action="'.$url.'" method="post"'.$enctype.'>';
-
+        
+        if ($options['public']) {
+            $html = '<form action="'.MvcRouter::public_url($router_options).'" method="post">';
+        } else {
+            $html = '<form action="'.MvcRouter::admin_url($router_options).'" method="post">';
+        }
+        
         if ($object_id) {
             $html .= '<input type="hidden" id="'.$this->input_id('hidden_id').'" name="'.$this->input_name('id').'" value="'.$object_id.'" />';
         }
@@ -63,34 +65,6 @@ class MvcFormHelper extends MvcHelper {
             'id' => $this->input_id($field_name),
             'name' => $this->input_name($field_name),
             'type' => 'text'
-        );
-        $options = array_merge($defaults, $options);
-        $attributes_html = self::attributes_html($options, 'input');
-        $html = $this->before_input($field_name, $options);
-        $html .= '<input'.$attributes_html.' />';
-        $html .= $this->after_input($field_name, $options);
-        return $html;
-    }
-    
-     public function number_input($field_name, $options=array()) {
-        $defaults = array(
-            'id' => $this->input_id($field_name),
-            'name' => $this->input_name($field_name),
-            'type' => 'number'
-        );
-        $options = array_merge($defaults, $options);
-        $attributes_html = self::attributes_html($options, 'input');
-        $html = $this->before_input($field_name, $options);
-        $html .= '<input'.$attributes_html.' />';
-        $html .= $this->after_input($field_name, $options);
-        return $html;
-    }
-    
-    public function email_input($field_name, $options=array()) {
-        $defaults = array(
-            'id' => $this->input_id($field_name),
-            'name' => $this->input_name($field_name),
-            'type' => 'email'
         );
         $options = array_merge($defaults, $options);
         $attributes_html = self::attributes_html($options, 'input');
@@ -244,7 +218,7 @@ class MvcFormHelper extends MvcHelper {
         return $html;
     }
     
-    public function has_many_dropdown($model_name, $select_options, $options=array()) {
+    public function has_many_dropdown($model_name, $select_options, $options=array(), $associated_objects=false) {
         $defaults = array(
             'select_id' => $this->model_name.'_'.$model_name.'_select',
             'select_name' => $this->model_name.'_'.$model_name.'_select',
@@ -263,7 +237,9 @@ class MvcFormHelper extends MvcHelper {
 
         // Fetch all associated objects.
         // If there aren't any, return empty array
-        $associated_objects = $this->object->{MvcInflector::tableize($model_name)};
+        if($associated_objects === false){
+            $associated_objects = $this->object->{MvcInflector::tableize($model_name)};
+        }
         $associated_objects = empty($associated_objects) ? array() : $associated_objects;
         
         // An empty value is necessary to ensure that data with name $options['ids_input_name'] is submitted; otherwise,

--- a/core/models/mvc_database_adapter.php
+++ b/core/models/mvc_database_adapter.php
@@ -111,7 +111,7 @@ class MvcDatabaseAdapter {
                     $values = implode(',', $values);
                     $sql_clauses[] = $this->escape($key).' IN ('.$values.')';
                 } else {
-                    $clauses = $this->get_where_sql_clauses($value);
+                    $clauses = $this->get_where_sql_clauses($value, $options);
                     $logical_operator = $key == 'OR' ? ' OR ' : ' AND ';
                     $sql_clauses[] = '('.implode($logical_operator, $clauses).')';
                 }
@@ -123,6 +123,7 @@ class MvcDatabaseAdapter {
             $operator = preg_match('/\s+(<|>|<=|>=|<>|\!=|[\w\s]+)/', $key) ? ' ' : ' = ';
             $sql_clauses[] = $this->escape($key).$operator.'"'.$this->escape($value).'"';
         }
+        
         return $sql_clauses;
     }
     

--- a/core/models/mvc_database_adapter.php
+++ b/core/models/mvc_database_adapter.php
@@ -123,7 +123,6 @@ class MvcDatabaseAdapter {
             $operator = preg_match('/\s+(<|>|<=|>=|<>|\!=|[\w\s]+)/', $key) ? ' ' : ' = ';
             $sql_clauses[] = $this->escape($key).$operator.'"'.$this->escape($value).'"';
         }
-        
         return $sql_clauses;
     }
     

--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -332,9 +332,9 @@ class MvcModel {
     
     protected function get_total_count($options=array()) {
         $clauses = $this->db_adapter->get_sql_select_clauses($options);
-        $clauses['select'] = 'SELECT COUNT(*) AS count';
         unset($clauses['limit']);
         $sql = implode(' ', $clauses);
+        $sql = 'SELECT COUNT(*) FROM('.$sql.') AS count';
         $result = $this->db_adapter->get_var($sql);
         return $result;
     }

--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -261,6 +261,7 @@ class MvcModel {
         $total_count = $this->get_total_count($options);
         $response = array(
             'objects' => $objects,
+            'total_objects' => $total_count,
             'total_pages' => ceil($total_count/$options['per_page']),
             'page' => $options['page']
         );
@@ -460,6 +461,33 @@ class MvcModel {
                     }
                 }
             }
+            //AR: improvement to add fields to join table
+            else if(is_array ($model_data[$association_name])){
+                $this->db_adapter->delete_all(array(
+                    'table_reference' => self::process_table_name($association['join_table']),
+                    'conditions' => array($association['foreign_key'] => $object_id)
+                ));
+                foreach ($model_data[$association_name] as $obj) {
+                    if(empty($obj['id']))
+                        continue;
+                    
+                    $fields = array(
+                        $association['foreign_key'] => $object_id,
+                    );
+                    //insert fields
+                    foreach ($obj as $field => $value) {
+                        $field = $field == 'id' ? $association['association_foreign_key'] : $field;
+                        $fields[$field] = $value;
+                    }
+                    
+                    $this->db_adapter->insert(
+                        $fields,
+                        array(
+                            'table_reference' => self::process_table_name($association['join_table'])
+                        )
+                    );
+                }
+            }
         }
     }
     
@@ -547,6 +575,7 @@ class MvcModel {
                             break;
                         
                         case 'has_and_belongs_to_many':
+                            
                             $join_alias = 'JoinTable';
                             $associated_objects = $model->find(array(
                                 'selects' => $association['fields'],
@@ -684,7 +713,14 @@ class MvcModel {
                     $association_name = $key;
                     if (isset($value['fields'])) {
                         foreach ($value['fields'] as $key => $field) {
-                            $value['fields'][$key] = $association_name.'.'.$field;
+                            if (strpos($field,'.') !== false) {
+                                //AR: contains '.', dont prepand a table
+                                $value['fields'][$key] = $field;
+                            }
+                            else{
+                                $value['fields'][$key] = $association_name.'.'.$field;
+                            }
+                            
                         }
                     }
                     $config = array(


### PR DESCRIPTION
Fix: model->get_total_count() retuns wrong value when using options['group']

query returns count for each group. (multiple rows)
Wrapping query: SELECT COUNT(*) FROM (...old query...) AS count