### PR TITLE
Fix: Plugin template apply router rules on plugin activation/deactiva…

### DIFF
--- a/core/models/mvc_database_adapter.php
+++ b/core/models/mvc_database_adapter.php
@@ -148,6 +148,9 @@ class MvcDatabaseAdapter {
             if (is_string($value) || is_numeric($value)) {
                 $clauses[] = $key.' = "'.$this->escape($value).'"';
             }
+            else if($value == null){
+                $clauses[] = $key.' = NULL';
+            }
         }
         $sql = implode(', ', $clauses);
         return $sql;

--- a/core/templates/plugin/plugin.php
+++ b/core/templates/plugin/plugin.php
@@ -12,15 +12,19 @@ register_activation_hook(__FILE__, '<?php echo $name_underscored; ?>_activate');
 register_deactivation_hook(__FILE__, '<?php echo $name_underscored; ?>_deactivate');
 
 function <?php echo $name_underscored; ?>_activate() {
+    global $wp_rewrite;
     require_once dirname(__FILE__).'/<?php echo $name_underscored; ?>_loader.php';
     $loader = new <?php echo $name_camelized; ?>Loader();
     $loader->activate();
+    $wp_rewrite->flush_rules( true );
 }
 
 function <?php echo $name_underscored; ?>_deactivate() {
+    global $wp_rewrite;
     require_once dirname(__FILE__).'/<?php echo $name_underscored; ?>_loader.php';
     $loader = new <?php echo $name_camelized; ?>Loader();
     $loader->deactivate();
+    $wp_rewrite->flush_rules( true );
 }
 
 <?php echo '?>'; ?>


### PR DESCRIPTION
Documentation does not mention to make wordpress recreate rewrite rules. With this change thats done on plugin activation/deactivation. (For new generated plugins)