### PR TITLE
allow using NULL in query conditions

### DIFF
--- a/core/models/mvc_database_adapter.php
+++ b/core/models/mvc_database_adapter.php
@@ -120,8 +120,12 @@ class MvcDatabaseAdapter {
             if (strpos($key, '.') === false && $use_table_alias) {
                 $key = $this->defaults['model_name'].'.'.$key;
             }
-            $operator = preg_match('/\s+(<|>|<=|>=|<>|\!=|[\w\s]+)/', $key) ? ' ' : ' = ';
-            $sql_clauses[] = $this->escape($key).$operator.'"'.$this->escape($value).'"';
+            if (!is_null($value)) {
+                $operator = preg_match('/\s+(<|>|<=|>=|<>|\!=|[\w\s]+)/', $key) ? ' ' : ' = ';
+                $sql_clauses[] = $this->escape($key).$operator.'"'.$this->escape($value).'"';
+            } else {
+                $sql_clauses[] = $this->escape($key).' IS NULL';
+            }
         }
         return $sql_clauses;
     }


### PR DESCRIPTION
Hi ! Did not see how to perform a "is null" condition.
I provided a way to do it, could you tell me if that's okay with you ?

eg :
```
$aParent = $oParent->find( array(
        'selects' => array('Post.post_title as label', $config['model'].'.id'),
        'order' => 'Post.post_title ASC',
        'conditions' => array(
            $config['model'].'.id_parent' => null, //will become a "IS NULL" condition
            $config['model'].'.id != ' => $oModel->id,
        ),
        'joins' => array('Post')
    ) );