### PR TITLE
Fix for Issue #116 Non-static method should not be called statically...

### DIFF
--- a/core/helpers/mvc_form_tags_helper.php
+++ b/core/helpers/mvc_form_tags_helper.php
@@ -3,7 +3,7 @@
 class MvcFormTagsHelper extends MvcHelper {
     
     // Generalized method that chooses the appropriate input type based on the SQL type of the field
-    public function input($field_name, $options=array()) {
+    static function input($field_name, $options=array()) {
         $defaults = array(
             'id' => self::input_id($field_name),
             'name' => self::input_name($field_name),
@@ -73,7 +73,7 @@ class MvcFormTagsHelper extends MvcHelper {
         return $html;
     }
     
-    public function checkbox_input($field_name, $options=array()) {
+    static function checkbox_input($field_name, $options=array()) {
         $defaults = array(
             'id' => self::input_id($field_name),
             'name' => self::input_name($field_name),
@@ -111,14 +111,14 @@ class MvcFormTagsHelper extends MvcHelper {
         return $html;
     }
     
-    public function select_input($field_name, $options=array()) {
+    static function select_input($field_name, $options=array()) {
         $html = self::before_input($field_name, $options);
         $html .= self::select_tag($field_name, $options);
         $html .= self::after_input($field_name, $options);
         return $html;
     }
     
-    public function select_tag($field_name, $options=array()) {
+    static function select_tag($field_name, $options=array()) {
         $defaults = array(
             'id' => self::input_id($field_name),
             'name' => self::input_name($field_name),
@@ -158,7 +158,7 @@ class MvcFormTagsHelper extends MvcHelper {
         return $html;
     }
     
-    private function before_input($field_name, $options) {
+    static private function before_input($field_name, $options) {
         $defaults = array(
             'before' => ''
         );
@@ -170,7 +170,7 @@ class MvcFormTagsHelper extends MvcHelper {
         return $html;
     }
     
-    private function after_input($field_name, $options) {
+    static private function after_input($field_name, $options) {
         $defaults = array(
             'after' => ''
         );
@@ -179,11 +179,11 @@ class MvcFormTagsHelper extends MvcHelper {
         return $html;
     }
     
-    private function input_id($field_name) {
+    static private function input_id($field_name) {
         return $field_name;
     }
     
-    private function input_name($field_name) {
+    static private function input_name($field_name) {
         return $field_name;
     }
 

--- a/core/helpers/mvc_helper.php
+++ b/core/helpers/mvc_helper.php
@@ -25,7 +25,7 @@ class MvcHelper {
         require $filepath;
     }
     
-    public function esc_attr($string) {
+    static function esc_attr($string) {
         return esc_attr($string);
     }
     

--- a/core/mvc_settings_registry.php
+++ b/core/mvc_settings_registry.php
@@ -4,7 +4,7 @@ class MvcSettingsRegistry {
 
     var $__settings = array();
 
-    private function &get_instance() {
+    static private function &get_instance() {
         static $instance = array();
         if (!$instance) {
             $mvc_settings_registry = new MvcSettingsRegistry();
@@ -13,7 +13,7 @@ class MvcSettingsRegistry {
         return $instance[0];
     }
 
-    public function &get_settings($key) {
+    static function &get_settings($key) {
         $_this =& self::get_instance();
         $key = MvcInflector::camelize($key);
         $return = false;


### PR DESCRIPTION
Added static changes to fix this problem with using the "heirarchical-documentation" example with WordPress 4.4.1 release (don't know if the problem exists in previous releases).