### PR TITLE
additional optional options for AdminPages and options to disable actions in admin index tables

### DIFF
--- a/core/helpers/mvc_helper.php
+++ b/core/helpers/mvc_helper.php
@@ -172,20 +172,20 @@ class MvcHelper {
         return '<th scope="col" class="manage-column">'.$label.'</th>';
     }
     
-    public function admin_table_cells($controller, $objects) {
+    public function admin_table_cells($controller, $objects, $options = array()) {
         $html = '';
         foreach ($objects as $object) {
             $html .= '<tr>';
             foreach ($controller->default_columns as $key => $column) {
-                $html .= $this->admin_table_cell($controller, $object, $column);
+                $html .= $this->admin_table_cell($controller, $object, $column, $options);
             }
-            $html .= $this->admin_actions_cell($controller, $object);
+            $html .= $this->admin_actions_cell($controller, $object, $options);
             $html .= '</tr>';
         }
         return $html;
     }
     
-    public function admin_table_cell($controller, $object, $column) {
+    public function admin_table_cell($controller, $object, $column, $options = array()) {
         if (!empty($column['value_method'])) {
             $value = $controller->{$column['value_method']}($object);
         } else {
@@ -194,13 +194,34 @@ class MvcHelper {
         return '<td>'.$value.'</td>';
     }
     
-    public function admin_actions_cell($controller, $object) {
+    public function admin_actions_cell($controller, $object, $options = array()) {
+        
+        $default = array(
+            'actions' => array(
+                'edit' => true,
+                'view' => true,
+                'delete' => true,
+            )
+        );
+        
+        $options = array_merge($default, $options);
+        
         $links = array();
         $object_name = empty($object->__name) ? 'Item #'.$object->__id : $object->__name;
         $encoded_object_name = $this->esc_attr($object_name);
-        $links[] = '<a href="'.MvcRouter::admin_url(array('object' => $object, 'action' => 'edit')).'" title="Edit '.$encoded_object_name.'">Edit</a>';
-        $links[] = '<a href="'.MvcRouter::public_url(array('object' => $object)).'" title="View '.$encoded_object_name.'">View</a>';
-        $links[] = '<a href="'.MvcRouter::admin_url(array('object' => $object, 'action' => 'delete')).'" title="Delete '.$encoded_object_name.'" onclick="return confirm(&#039;Are you sure you want to delete '.$encoded_object_name.'?&#039;);">Delete</a>';
+        
+        if($options['actions']['edit']){
+            $links[] = '<a href="'.MvcRouter::admin_url(array('object' => $object, 'action' => 'edit')).'" title="Edit '.$encoded_object_name.'">Edit</a>';
+        }
+        
+        if($options['actions']['view']){
+            $links[] = '<a href="'.MvcRouter::public_url(array('object' => $object)).'" title="View '.$encoded_object_name.'">View</a>';
+        }
+        
+        if($options['actions']['delete']){
+            $links[] = '<a href="'.MvcRouter::admin_url(array('object' => $object, 'action' => 'delete')).'" title="Delete '.$encoded_object_name.'" onclick="return confirm(&#039;Are you sure you want to delete '.$encoded_object_name.'?&#039;);">Delete</a>';
+        }
+
         $html = implode(' | ', $links);
         return '<td>'.$html.'</td>';
     }

--- a/core/loaders/mvc_admin_loader.php
+++ b/core/loaders/mvc_admin_loader.php
@@ -107,7 +107,7 @@ class MvcAdminLoader extends MvcLoader {
             
                 $method = $admin_controller_name.'_index';
                 $this->dispatcher->{$method} = create_function('', 'MvcDispatcher::dispatch(array("controller" => "'.$admin_controller_name.'", "action" => "index"));');
-                $capability = $this->admin_controller_capabilities[ $controller_name ];
+                $capability = !empty($pages['capability']) ? $pages['capability'] : $this->admin_controller_capabilities[ $controller_name ];
                 $label = !empty($pages['label']) ? $pages['label'] : $controller_titleized;
                 
                 if(empty($pages['parent_slug'])){

--- a/core/models/mvc_database_adapter.php
+++ b/core/models/mvc_database_adapter.php
@@ -127,10 +127,12 @@ class MvcDatabaseAdapter {
             
             if(in_array($value, $functions) || is_null($value)){
                 if((is_null($value) || $value === 'NULL')){
-                    if(trim($operator) == "=")
+                    if(trim($operator) == "="){
                         $operator = " IS ";
-                    else if(trim($operator) == "!=")
+                    }
+                    else if(trim($operator) == "!="){
                         $operator = " IS NOT ";
+                    }
                     $value = "NULL";
                 }
                 $sql_clauses[] = $this->escape($key).$operator.$value;

--- a/core/models/mvc_database_adapter.php
+++ b/core/models/mvc_database_adapter.php
@@ -131,6 +131,7 @@ class MvcDatabaseAdapter {
                         $operator = " IS ";
                     else if(trim($operator) == "!=")
                         $operator = " IS NOT ";
+                    $value = "NULL";
                 }
                 $sql_clauses[] = $this->escape($key).$operator.$value;
             }


### PR DESCRIPTION
examples:
Admin Pages:
`
MvcConfiguration::append(array(

    'AdminPages' => array(
        'book_db_sync' => array(
            'config' => array(
                'label' => "label",
                'capability' => 'ba_synchronisation'
                ),
            'label' => "label",
            'icon' => 'dashicons-download',
            'order' => 10,
        ),
    )
));
`

//app/views/admin/modelA/index.php
`

       <tbody>
        <?php
        $options = array(
            'actions' => array(
                'edit' => current_user_can( 'ba_books_edit' ),
                'view' => true,
                'delete' => current_user_can( 'ba_books_delete' ),
            )
        );
        ?>
        <?php echo $helper->admin_table_cells($this, $objects, $options); ?>
    </tbody>
`