### PR TITLE
Minor fix to form helper

### DIFF
--- a/core/helpers/mvc_form_helper.php
+++ b/core/helpers/mvc_form_helper.php
@@ -33,7 +33,7 @@ class MvcFormHelper extends MvcHelper {
     
     public function end($label='Submit') {
         $html = "";
-        // Allows the ommission of Submit button from end of form if $label == false. Useful for using custom submit buttons with more specific stylings etc..
+        // Allows the omission of Submit button from end of form if $label == false. Useful for using custom submit buttons with more specific stylings etc..
         if ($label) {
             $html = '<div><input type="submit" value="'.$this->esc_attr($label).'" /></div>';
         }

--- a/core/helpers/mvc_form_helper.php
+++ b/core/helpers/mvc_form_helper.php
@@ -32,8 +32,14 @@ class MvcFormHelper extends MvcHelper {
     }
     
     public function end($label='Submit') {
-        $html = '<div><input type="submit" value="'.$this->esc_attr($label).'" /></div>';
+        $html = "";
+        // Allows the ommission of Submit button from end of form if $label == false. Useful for using custom submit buttons with more specific stylings etc..
+        if ($label) {
+            $html = '<div><input type="submit" value="'.$this->esc_attr($label).'" /></div>';
+        }
+
         $html .= '</form>';
+
         return $html;
     }
     


### PR DESCRIPTION
All other form input helpers can have attributes added, except the last submit button baked into the form end i.e.:
 `<?php echo $this->form->end('Some form button text'); ?>`. 

At the very least we need the ability to omit the button like so:
`<?php echo $this->form->end(false); ?>`