### PR TITLE
Validation upon object creation.

### DIFF
--- a/core/controllers/mvc_admin_controller.php
+++ b/core/controllers/mvc_admin_controller.php
@@ -41,11 +41,15 @@ class MvcAdminController extends MvcController {
         if (!empty($this->params['data'][$this->model->name])) {
             $object = $this->params['data'][$this->model->name];
             if (empty($object['id'])) {
-                $this->model->create($this->params['data']);
-                $id = $this->model->insert_id;
-                $url = MvcRouter::admin_url(array('controller' => $this->name, 'action' => 'edit', 'id' => $id));
-                $this->flash('notice', 'Successfully created!');
-                $this->redirect($url);
+                if($this->model->create($this->params['data'])) {
+                    $id = $this->model->insert_id;
+                    $url = MvcRouter::admin_url(array('controller' => $this->name, 'action' => 'edit', 'id' => $id));
+                    $this->flash('notice', 'Successfully created!');
+                    $this->redirect($url);
+                } else {
+                    $this->flash('error', $this->model->validation_error_html);
+                    $this->set_object();
+                }
             } else {
                 if ($this->model->save($this->params['data'])) {
                     $this->flash('notice', 'Successfully saved!');

--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -537,7 +537,7 @@ class MvcModel {
                 $object = $this->new_object($array);
             }
             
-            if ( (!empty($this->primary_key)) && (!empty($object->id)) ) {
+            if ( (!empty($this->primary_key)) && (!empty($object->{$this->primary_key})) ) {
                 $object->__id = $object->{$this->primary_key};
             }
             

--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -537,7 +537,7 @@ class MvcModel {
                 $object = $this->new_object($array);
             }
             
-            if (!empty($this->primary_key)) {
+            if ( (!empty($this->primary_key)) && (!empty($object->id)) ) {
                 $object->__id = $object->{$this->primary_key};
             }
             


### PR DESCRIPTION
I had the same problem as issue #124 (validation not working on object creation). This commit resolved it for me on WordPress 4.5.2 but I've not performed tests of all affected code.