### PR TITLE
Added WP editor as new form element

### DIFF
--- a/core/helpers/mvc_form_helper.php
+++ b/core/helpers/mvc_form_helper.php
@@ -145,7 +145,7 @@ class MvcFormHelper extends MvcHelper {
         return $html;
     }
 
-    public function editor($field_name, array $options = []) {
+    public function editor($field_name, array $options = array()) {
         $id = $this->input_id($field_name);
 
         $defaults = array(
@@ -164,22 +164,22 @@ class MvcFormHelper extends MvcHelper {
 
         ob_start();
 
-        if ($options['label'])
+        if (!empty($options['label']))
             echo '<label for="' . $id . '">' . $options['label'] . '</label>';
 
-        wp_editor($options['content'], $id, [
+        wp_editor($options['content'], $id, array(
             'editor_class' => $options['required'],
             'media_buttons' => $options['media_buttons'],
             'textarea_name' => $options['name'],
             'textarea_rows' => $options['rows'],
             'teeny' => $options['minimal'],
-            'tinymce' => [
+            'tinymce' => array(
                 'statusbar' => $options['statusbar']
-            ],
+            ),
             'editor_css' => $options['editor_css'],
             'quicktags' => $options['quicktags'],
             'wpautop' => false
-        ]);
+        ));
 
         return ob_get_clean();
     }

--- a/core/helpers/mvc_form_helper.php
+++ b/core/helpers/mvc_form_helper.php
@@ -144,6 +144,45 @@ class MvcFormHelper extends MvcHelper {
         $html .= $this->after_input($field_name, $options);
         return $html;
     }
+
+    public function editor($field_name, array $options = []) {
+        $id = $this->input_id($field_name);
+
+        $defaults = array(
+            'id' => $id,
+            'name' => $this->input_name($field_name),
+            'label' => MvcInflector::titleize($field_name),
+            'content' => empty($this->object->$field_name) ? '' : $this->object->$field_name,
+            'rows' => 10,
+            'editor_css' => '',
+            'media_buttons' => true,
+            'minimal' => false,
+            'statusbar' => true,
+            'quicktags' => true
+        );
+        $options = array_merge($defaults, $options);
+
+        ob_start();
+
+        if ($options['label'])
+            echo '<label for="' . $id . '">' . $options['label'] . '</label>';
+
+        wp_editor($options['content'], $id, [
+            'editor_class' => $options['required'],
+            'media_buttons' => $options['media_buttons'],
+            'textarea_name' => $options['name'],
+            'textarea_rows' => $options['rows'],
+            'teeny' => $options['minimal'],
+            'tinymce' => [
+                'statusbar' => $options['statusbar']
+            ],
+            'editor_css' => $options['editor_css'],
+            'quicktags' => $options['quicktags'],
+            'wpautop' => false
+        ]);
+
+        return ob_get_clean();
+    }
     
     public function select($field_name, $options=array()) {
         $html = $this->before_input($field_name, $options);


### PR DESCRIPTION
Feature #126 

What do you think? As wp_editor() unfortunately echos the HTML directly, I used an output buffer.

Also I used array short syntax (supported since PHP v5.4). I think it's pretty safe to use nowadays, but if you'd like to support PHP 5.3 and below, I can also use the old syntax. I simply like it more personally.