### PR TITLE
better database integrity support

### DIFF
--- a/core/models/mvc_database_adapter.php
+++ b/core/models/mvc_database_adapter.php
@@ -163,12 +163,12 @@ class MvcDatabaseAdapter {
     public function get_set_sql($data) {
         $clauses = array();
         foreach ($data as $key => $value) {
-            if (is_string($value) || is_numeric($value)) {
-                $clauses[] = $key.' = "'.$this->escape($value).'"';
-            }
-            else if($value == null){
+            if ($value == null) {
                 $clauses[] = $key.' = NULL';
             }
+            else if (is_string($value) || is_numeric($value)) {
+                $clauses[] = $key . ' = "' . $this->escape($value) . '"';
+            }            
         }
         $sql = implode(', ', $clauses);
         return $sql;


### PR DESCRIPTION
- There is a problem when foreign keys are used and for example dropdown
is changed to empty value:

WP-MVC tries to write "" value which results into 0 written without
foreign keys used; this is acceptable but not quite correct.

When foreign key is used this try of course fails if you don't have
a 0 Id in the table; which is not quite common.

The fix just makes from "" value NULL value which makes update operation
more correct.