### PR TITLE
Fix null type comparison issue when saving data

### DIFF
--- a/core/models/mvc_database_adapter.php
+++ b/core/models/mvc_database_adapter.php
@@ -184,7 +184,7 @@ class MvcDatabaseAdapter {
     public function get_insert_values_sql($data) {
         $values = array();
         foreach ($data as $value) {
-            if($value == null){
+            if($value === null){
                 $values[] = 'NULL';
             }
             else{

--- a/core/models/mvc_database_adapter.php
+++ b/core/models/mvc_database_adapter.php
@@ -184,10 +184,13 @@ class MvcDatabaseAdapter {
     public function get_insert_values_sql($data) {
         $values = array();
         foreach ($data as $value) {
-            if($value === null){
+            if ($value === null) {
                 $values[] = 'NULL';
-            }
-            else{
+            } elseif ($value === false) {
+                $values[] = 'FALSE';
+            } elseif ($value === true) {
+                $values[] = 'TRUE';
+            } else {
                 $values[] = '"'.$this->escape($value).'"';
             }
         }


### PR DESCRIPTION
When saving data, we should only insert a `NULL` if the user explicitly passes a null value, not if the user passes a `0` as an integer or float.

Otherwise this causes issues if the mysql schema defines a field as `NOT NULL`.