### PR TITLE
added mvc_layout argument to ->query_vars in MvcLoader class

### DIFF
--- a/core/loaders/mvc_loader.php
+++ b/core/loaders/mvc_loader.php
@@ -19,8 +19,8 @@ abstract class MvcLoader {
         
         $this->core_path = MVC_CORE_PATH;
 
-        $this->query_vars = array('mvc_controller','mvc_action','mvc_id','mvc_extra');
-        
+        // mdc added mvc_layout to allow routes to specify a layout to use.
+        $this->query_vars = array('mvc_controller','mvc_action','mvc_id','mvc_extra','mvc_layout');
         $this->load_core();
         $this->load_plugins();
         


### PR DESCRIPTION
My first pull request ever so hope this is the way to do it.  

To have the ability to have different layouts for different routes.  Add "mvc_layout" to the $this->query_vars array below:

$this->query_vars = array('mvc_controller','mvc_action','mvc_id','mvc_extra','mvc_layout');

Now this route works as expected:
MvcRouter::public_connect('{:controller}/{🆔[\d]+}', array('action' => 'show', 'layout' => 'mylayout'));

This array is located in the below class:

abstract class MvcLoader {
....................
function __construct() {
..................
 $this->query_vars = array('mvc_controller','mvc_action','mvc_id','mvc_extra','mvc_layout');

Thanks!
--Mike Clark