### PR TITLE
add primary key as second parameter to before_save

### DIFF
--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -126,7 +126,7 @@ class MvcModel {
                 return false;
             }
             if (method_exists($this, 'before_save')) {
-                if (!$this->before_save($model_data)) {
+                if (!$this->before_save($model_data, $id)) {
                     return false;
                 }
             }

--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -90,7 +90,8 @@ class MvcModel {
         }
         $model_data = $data[$this->name];
         if (method_exists($this, 'before_save')) {
-            if (!$this->before_save($model_data)) {
+            // second parameter represents id
+            if( ! $this->before_save($model_data, null)) {
                 return false;
             }
         }


### PR DESCRIPTION
I'm using an additional field in a join table. When updating a parent record via admin view all existing entries in the join table are deleted and then recreated by MvcModel->update_has_and_belongs_to_many_associations(). A possible workaround to preserve the additional field values is to define a before_save method in my derived model and to grab and add those values there to the model_data parameter. Unfortunately the model_data parameter does not hold the id of the instance that is being updated making it impossible to find the field values. The primary_key is unset in MvcModel->save() a few lines earlier:

`unset($model_data[$this->primary_key]);`

My fix is to add the id parameter as a second parameter to before_save:

`if (!$this->before_save($model_data, $id))`