### PR TITLE
issue-183-multisite-fix

### DIFF
--- a/core/functions/functions.php
+++ b/core/functions/functions.php
@@ -25,7 +25,7 @@ function mvc_model($model_name) {
 
 function mvc_setting($settings_name, $setting_key) {
     $settings_name = 'mvc_'.MvcInflector::underscore($settings_name);
-    $option = get_option($settings_name);
+    $option = get_site_option($settings_name);
     if (isset($option[$setting_key])) {
         return $option[$setting_key];
     }
@@ -98,7 +98,7 @@ function mvc_add_plugin($plugin) {
         $plugins[] = $plugin;
         $added = true;
     }
-    update_option('mvc_plugins', $plugins);
+    update_site_option('mvc_plugins', $plugins);
     return $added;
 }
 
@@ -114,12 +114,12 @@ function mvc_remove_plugin($plugin) {
         }
         $plugins = array_values($plugins);
     }
-    update_option('mvc_plugins', $plugins);
+    update_site_option('mvc_plugins', $plugins);
     return $removed;
 }
 
 function mvc_get_plugins() {
-    $plugins = get_option('mvc_plugins', array());
+    $plugins = get_site_option('mvc_plugins', array());
     return $plugins;
 }
 

--- a/core/loaders/mvc_loader.php
+++ b/core/loaders/mvc_loader.php
@@ -105,7 +105,7 @@ abstract class MvcLoader {
     
     protected function get_ordered_plugins() {
     
-        $plugins = get_option('mvc_plugins', array());
+        $plugins = get_site_option('mvc_plugins', array());
         $plugin_app_paths = array();
         
         // Allow plugins to be loaded in a specific order by setting a PluginOrder config value like

--- a/core/mvc_plugin_loader.php
+++ b/core/mvc_plugin_loader.php
@@ -56,7 +56,7 @@ class MvcPluginLoader {
     
     protected function update_registered_plugins($plugins) {
         $plugins = $this->filter_nonexistent_plugins($plugins);
-        update_option('mvc_plugins', $plugins);
+        update_site_option('mvc_plugins', $plugins);
     }
     
     protected function filter_nonexistent_plugins($plugins) {
@@ -79,7 +79,7 @@ class MvcPluginLoader {
     }
     
     protected function get_plugins() {
-        $plugins = get_option('mvc_plugins', array());
+        $plugins = get_site_option('mvc_plugins', array());
         return $plugins;
     }
     
@@ -91,7 +91,7 @@ class MvcPluginLoader {
             foreach ($settings_files as $file_path) {
                 $settings_class = MvcInflector::class_name_from_filename(basename($file_path));
                 $settings = new $settings_class();
-                $existing_values = get_option($settings->key);
+                $existing_values = get_site_option($settings->key);
                 if (!$existing_values) {
                     $values = array();
                     foreach ($settings->settings as $key => $setting) {
@@ -103,7 +103,7 @@ class MvcPluginLoader {
                         }
                         $values[$key] = $value;
                     }
-                    update_option($settings->key, $values);
+                    update_site_option($settings->key, $values);
                 }
             }
         }

--- a/core/mvc_settings.php
+++ b/core/mvc_settings.php
@@ -30,7 +30,7 @@ class MvcSettings {
     
     public function display_field($setting_key) {
         $setting = $this->settings[$setting_key];
-        $options = get_option($this->key);
+        $options = get_site_option($this->key);
         $value = isset($options[$setting_key]) ? $options[$setting_key] : null;
         if (is_null($value)) {
             if (!empty($setting['default'])) {

--- a/examples/events-calendar-example/app/models/speaker.php
+++ b/examples/events-calendar-example/app/models/speaker.php
@@ -3,7 +3,7 @@
 class Speaker extends MvcModel {
 
     var $order = 'Speaker.first_name, Speaker.last_name';
-    var $display_field = 'name';
+    var $display_field = 'first_name';
     var $has_many = array('Event');
     var $wp_post = array(
         'post_type' => array(
@@ -30,10 +30,6 @@ class Speaker extends MvcModel {
             'message' => 'Please enter a valid URL in the URL field!'
         )
     );
-    
-    public function after_find($object) {
-        $object->name = trim($object->first_name.' '.$object->last_name);
-    }
     
 }
 

--- a/examples/events-calendar-example/events_calendar_example.php
+++ b/examples/events-calendar-example/events_calendar_example.php
@@ -8,19 +8,36 @@ Version: 1.0
 Author URI: 
 */
 
+// register activation hook for when the plugin is installed.
 register_activation_hook(__FILE__, 'events_calendar_example_activate');
-register_deactivation_hook(__FILE__, 'events_calendar_example_deactivate');
-
-function events_calendar_example_activate() {
+function events_calendar_example_activate($network_wide) {
     require_once dirname(__FILE__).'/events_calendar_example_loader.php';
     $loader = new EventsCalendarExampleLoader();
-    $loader->activate();
+    $loader->activate($network_wide);
 }
 
-function events_calendar_example_deactivate() {
+// register deactivation hook for when the plugin is uninstalled
+register_deactivation_hook(__FILE__, 'events_calendar_example_deactivate');
+function events_calendar_example_deactivate($network_wide) {
     require_once dirname(__FILE__).'/events_calendar_example_loader.php';
     $loader = new EventsCalendarExampleLoader();
-    $loader->deactivate();
+    $loader->deactivate($network_wide);
+}
+
+// register an action handler for when a new blog is created in a multisite environment
+add_action('wpmu_new_blog', 'events_calendar_example_on_create_blog');
+function events_calendar_example_on_create_blog($blog_id) {
+    require_once dirname(__FILE__).'/events_calendar_example_loader.php';
+    $loader = new EventsCalendarExampleLoader();
+    $loader->activate_blog($blog_id);
+}
+
+// register an action handler for when a blog is deleted in a multisite environent
+add_action('deleted_blog', 'events_calendar_example_on_delete_blog');
+function events_calendar_example_on_delete_blog($blog_id) {
+    require_once dirname(__FILE__).'/events_calendar_example_loader.php';
+    $loader = new EventsCalendarExampleLoader();
+    $loader->deactivate_blog($blog_id);
 }
 
 ?>

--- a/examples/events-calendar-example/events_calendar_example_loader.php
+++ b/examples/events-calendar-example/events_calendar_example_loader.php
@@ -1,36 +1,151 @@
 <?php
 
+/**
+ *
+ * Simple Example class for a multisite safe plugin
+ *
+ * @class EventsCalendarExampleLoader
+ *
+ * @author Nicolas Gosselin
+ */
 class EventsCalendarExampleLoader extends MvcPluginLoader {
 
-    var $db_version = '1.0';
-    
-    function init() {
-    
-        // Include any code here that needs to be called when this class is instantiated
-    
+  /**
+   * @var float $db_version
+   *
+   * Version number to put in DB
+   */
+  private $db_version = 2.0;
+
+  /**
+   * @var array $tables
+   *
+   * Variable to store the tables to create
+   */
+  private $tables = array();
+
+  public function init() {}
+
+  public function activate($network_wide = FALSE) {
+      global $wpdb;
+
+      require_once ABSPATH.'wp-admin/includes/upgrade.php';
+
+      // check if it is a network activation - if so, run the activation public function for each blog id
+      if ($network_wide && function_exists('is_multisite') && is_multisite()) {
+
+          // Get all blog ids and activate / create tables on each current
+          // exisiting blog
+          $blog_ids = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
+          foreach ($blog_ids as $blog_id) {
+            $this->activate_blog($blog_id);
+          }
+      }
+      else
+      {
+        // single blog
+        $this->activate_blog();
+      }
+
+      // This call needs to be made to activate this app within WP MVC
+      $this->activate_app(__FILE__);
+
+      return;
+  }
+
+  public function deactivate($network_wide = FALSE) {
+    global $wpdb;
+
+    require_once ABSPATH.'wp-admin/includes/upgrade.php';
+
+    // This call needs to be made to deactivate this app within WP MVC
+    $this->deactivate_app(__FILE__);
+
+    // check if it is a network activation - if so, run the deactivation public function for each blog id
+    if ($network_wide && function_exists('is_multisite') && is_multisite()) {
+      // check if it is a network activation - if so, run the activation public function for each blog id
+        if (!empty($network_wide) && $network_wide) {
+            // Get all blog ids
+            $blog_ids = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
+            foreach ($blog_ids as $blog_id) {
+              $this->deactivate_blog($blog_id);
+            }
+        }
+    }
+    else
+    {
+      // single blog
+      $this->deactivate_blog();
+    }
+
+    return;
+  }
+
+  /**
+   * activate_blog()
+   *
+   * Setup the required tables for the plugin for $blog_id.
+   *
+   * @param $blog_id - The id of the blog to work against
+   *
+   * @return void
+   */
+  public function activate_blog($blog_id = 1) {
+    if ($blog_id == 1) {
+      add_option('events_calendar_example_db_version', $this->db_version);
+      $this->create_tables();
+    }
+    else
+    {
+      switch_to_blog($blog_id);
+      add_option('events_calendar_example_db_version', $this->db_version);
+      $this->create_tables();
+      restore_current_blog();
+    }
+  }
+
+  /**
+   * deactivate_blog()
+   *
+   * Remove the tables used by the plugin for $blog_id.
+   *
+   * @param $blog_id - The id of the blog to work against
+   *
+   * @return void
+   */
+  public function deactivate_blog($blog_id = 1) {
+    if ($blog_id == 1) {
+      delete_option('events_calendar_example_db_version');
+      $this->delete_tables();
+    }
+    else
+    {
+      switch_to_blog($blog_id);
+      delete_option('events_calendar_example_db_version');
+      $this->delete_tables();
+      restore_current_blog();
+    }
+  }
+
+  /**
+   * create_tables()
+   *
+   * Create the required table for the plugin.
+   *
+   * @return void
+   */
+  private function create_tables() {
         global $wpdb;
-    
+
+        // this needs to occur at this level, and not in the
+        // constructor/init since we are switching blogs for multisite
         $this->tables = array(
             'events' => $wpdb->prefix.'events',
             'events_speakers' => $wpdb->prefix.'events_speakers',
             'speakers' => $wpdb->prefix.'speakers',
             'venues' => $wpdb->prefix.'venues'
         );
-    
-    }
 
-    function activate() {
-    
-        // This call needs to be made to activate this app within WP MVC
-        
-        $this->activate_app(__FILE__);
-        
-        // Perform any databases modifications related to plugin activation here, if necessary
-
-        require_once ABSPATH.'wp-admin/includes/upgrade.php';
-    
-        add_option('events_calendar_example_db_version', $this->db_version);
-    
         $sql = '
             CREATE TABLE '.$this->tables['events'].' (
               id int(11) NOT NULL auto_increment,
@@ -43,7 +158,7 @@ class EventsCalendarExampleLoader extends MvcPluginLoader {
               KEY venue_id (venue_id)
             )';
         dbDelta($sql);
-    
+
         $sql = '
             CREATE TABLE '.$this->tables['events_speakers'].' (
               id int(7) NOT NULL auto_increment,
@@ -54,7 +169,7 @@ class EventsCalendarExampleLoader extends MvcPluginLoader {
               KEY speaker_id (speaker_id)
             )';
         dbDelta($sql);
-    
+
         $sql = '
             CREATE TABLE '.$this->tables['speakers'].' (
               id int(8) NOT NULL auto_increment,
@@ -67,7 +182,7 @@ class EventsCalendarExampleLoader extends MvcPluginLoader {
               KEY post_id (post_id)
             )';
         dbDelta($sql);
-    
+
         $sql = '
             CREATE TABLE '.$this->tables['venues'].' (
               id int(11) NOT NULL auto_increment,
@@ -85,187 +200,212 @@ class EventsCalendarExampleLoader extends MvcPluginLoader {
               KEY post_id (post_id)
             )';
         dbDelta($sql);
-        
+
         $this->insert_example_data();
-        
     }
 
-    function deactivate() {
-    
-        // This call needs to be made to deactivate this app within WP MVC
-        
-        $this->deactivate_app(__FILE__);
-        
-        // Perform any databases modifications related to plugin deactivation here, if necessary
-    
-    }
-    
-    function insert_example_data() {
-    
-        // Only insert the example data if no data already exists
-        
-        $sql = '
-            SELECT
-                id
-            FROM
-                '.$this->tables['events'].'
-            LIMIT
-                1';
-        $data_exists = $this->wpdb->get_var($sql);
-        if ($data_exists) {
-            return false;
-        }
-        
-        // Insert example data
-        
-        $rows = array(
-            array(
-                'id' => 1,
-                'venue_id' => 2,
-                'date' => '2011-06-17',
-                'time' => '18:00:00',
-                'description' => '',
-                'is_public' => 1
-            ),
-            array(
-                'id' => 2,
-                'venue_id' => 2,
-                'date' => '2011-11-10',
-                'time' => '15:43:00',
-                'description' => '',
-                'is_public' => 1
-            ),
-            array(
-                'id' => 3,
-                'venue_id' => 1,
-                'date' => '2011-08-14',
-                'time' => '18:00:00',
-                'description' => 'Description about this event...',
-                'is_public' => 1
-            )
-        );
-        foreach($rows as $row) {
-            $this->wpdb->insert($this->tables['events'], $row);
-        }
-        
-        $rows = array(
-            array(
-                'event_id' => 1,
-                'speaker_id' => 5
-            ),
-            array(
-                'event_id' => 1,
-                'speaker_id' => 4
-            ),
-            array(
-                'event_id' => 2,
-                'speaker_id' => 6
-            ),
-            array(
-                'event_id' => 2,
-                'speaker_id' => 3
-            ),
-            array(
-                'event_id' => 2,
-                'speaker_id' => 2
-            ),
-            array(
-                'event_id' => 3,
-                'speaker_id' => 5
-            ),
-            array(
-                'event_id' => 3,
-                'speaker_id' => 6
-            ),
-            array(
-                'event_id' => 3,
-                'speaker_id' => 3
-            )
-        );
-        foreach($rows as $row) {
-            $this->wpdb->insert($this->tables['events_speakers'], $row);
-        }
-        
-        $rows = array(
-            array(
-                'id' => 1,
-                'first_name' => 'Maurice',
-                'last_name' => 'Deebank',
-                'url' => 'http://maurice.com',
-                'description' => 'Maurice\'s bio...'
-            ),
-            array(
-                'id' => 2,
-                'first_name' => 'Gary',
-                'last_name' => 'Ainge',
-                'url' => 'http://gary.com',
-                'description' => 'Gary\'s bio...'
-            ),
-            array(
-                'id' => 3,
-                'first_name' => 'Martin',
-                'last_name' => 'Duffy',
-                'url' => 'http://martin.com',
-                'description' => 'Martin\'s bio...'
-            ),
-            array(
-                'id' => 4,
-                'first_name' => 'Marco',
-                'last_name' => 'Thomas',
-                'url' => 'http://marco.com',
-                'description' => 'Marco\'s bio...'
-            ),
-            array(
-                'id' => 5,
-                'first_name' => 'Nick',
-                'last_name' => 'Gilbert',
-                'url' => 'http://nick.com',
-                'description' => 'Nick\'s bio...'
-            ),
-            array(
-                'id' => 6,
-                'first_name' => 'Mick',
-                'last_name' => 'Lloyd',
-                'url' => 'http://mick.com',
-                'description' => 'Mick\'s bio...'
-            )
-        );
-        foreach($rows as $row) {
-            $this->wpdb->insert($this->tables['speakers'], $row);
-        }
-        
-        $rows = array(
-            array(
-                'id' => 1,
-                'name' => 'Cabell Auditorium',
-                'sort_name' => 'Cabell Auditorium',
-                'url' => 'http://cabellauditorium.com',
-                'description' => '',
-                'address1' => '10 E 15th St',
-                'address2' => '',
-                'city' => 'New York',
-                'state' => 'NY',
-                'zip' => '10003'
-            ),
-            array(
-                'id' => 2,
-                'name' => 'Farveson Hall',
-                'sort_name' => 'Farveson Hall',
-                'url' => 'http://farvesonhall.org',
-                'description' => '',
-                'address1' => '216 W 21st St',
-                'address2' => '',
-                'city' => 'New York',
-                'state' => 'NY',
-                'zip' => '10011'
-            )
-        );
-        foreach($rows as $row) {
-            $this->wpdb->insert($this->tables['venues'], $row);
-        }
-    
-    }
+  /**
+   * delete_tables()
+   *
+   * Delete the tables which are required by the plugin.
+   *
+   * @return void
+   */
+  private function delete_tables() {
+      global $wpdb;
 
+      // this needs to occur at this level, and not in the
+      // constructor/init since we are switching blogs for multisite
+      $this->tables = array(
+          'events' => $wpdb->prefix.'events',
+          'events_speakers' => $wpdb->prefix.'events_speakers',
+          'speakers' => $wpdb->prefix.'speakers',
+          'venues' => $wpdb->prefix.'venues'
+      );
+
+      $sql = 'DROP TABLE IF EXISTS ' . $this->tables['events'];
+      $wpdb->query($sql);
+
+      $sql = 'DROP TABLE IF EXISTS ' . $this->tables['events_speakers'];
+      $wpdb->query($sql);
+
+      $sql = 'DROP TABLE IF EXISTS ' . $this->tables['speakers'];
+      $wpdb->query($sql);
+
+      $sql = 'DROP TABLE IF EXISTS ' . $this->tables['venues'];
+      $wpdb->query($sql);
+  }
+
+  /**
+   * insert_example_data()
+   *
+   * Insert some dummy data
+   *
+   * @return void
+   */
+  private function insert_example_data() {
+      // Only insert the example data if no data already exists
+
+      $sql = '
+          SELECT
+              id
+          FROM
+              '.$this->tables['events'].'
+          LIMIT
+              1';
+      $data_exists = $this->wpdb->get_var($sql);
+      if ($data_exists) {
+          return false;
+      }
+
+      // Insert example data
+
+      $rows = array(
+          array(
+              'id' => 1,
+              'venue_id' => 2,
+              'date' => '2011-06-17',
+              'time' => '18:00:00',
+              'description' => '',
+              'is_public' => 1
+          ),
+          array(
+              'id' => 2,
+              'venue_id' => 2,
+              'date' => '2011-11-10',
+              'time' => '15:43:00',
+              'description' => '',
+              'is_public' => 1
+          ),
+          array(
+              'id' => 3,
+              'venue_id' => 1,
+              'date' => '2011-08-14',
+              'time' => '18:00:00',
+              'description' => 'Description about this event...',
+              'is_public' => 1
+          )
+      );
+      foreach($rows as $row) {
+          $this->wpdb->insert($this->tables['events'], $row);
+      }
+
+      $rows = array(
+          array(
+              'event_id' => 1,
+              'speaker_id' => 5
+          ),
+          array(
+              'event_id' => 1,
+              'speaker_id' => 4
+          ),
+          array(
+              'event_id' => 2,
+              'speaker_id' => 6
+          ),
+          array(
+              'event_id' => 2,
+              'speaker_id' => 3
+          ),
+          array(
+              'event_id' => 2,
+              'speaker_id' => 2
+          ),
+          array(
+              'event_id' => 3,
+              'speaker_id' => 5
+          ),
+          array(
+              'event_id' => 3,
+              'speaker_id' => 6
+          ),
+          array(
+              'event_id' => 3,
+              'speaker_id' => 3
+          )
+      );
+      foreach($rows as $row) {
+          $this->wpdb->insert($this->tables['events_speakers'], $row);
+      }
+
+      $rows = array(
+          array(
+              'id' => 1,
+              'first_name' => 'Maurice',
+              'last_name' => 'Deebank',
+              'url' => 'http://maurice.com',
+              'description' => 'Maurice\'s bio...'
+          ),
+          array(
+              'id' => 2,
+              'first_name' => 'Gary',
+              'last_name' => 'Ainge',
+              'url' => 'http://gary.com',
+              'description' => 'Gary\'s bio...'
+          ),
+          array(
+              'id' => 3,
+              'first_name' => 'Martin',
+              'last_name' => 'Duffy',
+              'url' => 'http://martin.com',
+              'description' => 'Martin\'s bio...'
+          ),
+          array(
+              'id' => 4,
+              'first_name' => 'Marco',
+              'last_name' => 'Thomas',
+              'url' => 'http://marco.com',
+              'description' => 'Marco\'s bio...'
+          ),
+          array(
+              'id' => 5,
+              'first_name' => 'Nick',
+              'last_name' => 'Gilbert',
+              'url' => 'http://nick.com',
+              'description' => 'Nick\'s bio...'
+          ),
+          array(
+              'id' => 6,
+              'first_name' => 'Mick',
+              'last_name' => 'Lloyd',
+              'url' => 'http://mick.com',
+              'description' => 'Mick\'s bio...'
+          )
+      );
+      foreach($rows as $row) {
+          $this->wpdb->insert($this->tables['speakers'], $row);
+      }
+
+      $rows = array(
+          array(
+              'id' => 1,
+              'name' => 'Cabell Auditorium',
+              'sort_name' => 'Cabell Auditorium',
+              'url' => 'http://cabellauditorium.com',
+              'description' => '',
+              'address1' => '10 E 15th St',
+              'address2' => '',
+              'city' => 'New York',
+              'state' => 'NY',
+              'zip' => '10003'
+          ),
+          array(
+              'id' => 2,
+              'name' => 'Farveson Hall',
+              'sort_name' => 'Farveson Hall',
+              'url' => 'http://farvesonhall.org',
+              'description' => '',
+              'address1' => '216 W 21st St',
+              'address2' => '',
+              'city' => 'New York',
+              'state' => 'NY',
+              'zip' => '10011'
+          )
+      );
+      foreach($rows as $row) {
+          $this->wpdb->insert($this->tables['venues'], $row);
+      }
+  }
 }
 
 ?>


### PR DESCRIPTION
Change to make wp-mvc be friendly with multisite install as well as
single site setups.

The core is changed to use get_site_option, update_site_option opposed
to get_option and update_option which are not multisite friendly.

With the new functions in use, the events-calendar-example plugin was
updated in order to be an example on how to make a plugin that is both
multsite friendly and single site friendly.

The new plugin ends up having their own sets of database tables for
their blog.  ({prefix}_tablename, e.g wp_350_events)