### PR TITLE
Added headers not sent check

### DIFF
--- a/core/controllers/mvc_controller.php
+++ b/core/controllers/mvc_controller.php
@@ -15,7 +15,7 @@ class MvcController {
     function __construct() {
 
         // Necessary for flash()-related functionality
-        if (session_id() == '') {
+        if (session_id() == '' && !headers_sent()) {
             session_start();
         }
 


### PR DESCRIPTION
A small fix to eliminate a ton of these errors in my logs:

_PHP message: PHP Warning:  session_start(): Cannot send session cookie - headers already sent by (output started at .../releases/20170828233146/web/app/themes/ample-pro/page.php:10) in .../releases/20170828233146/web/app/plugins/wp-mvc/core/controllers/mvc_controller.php on line 19_