### PR TITLE
fixed select tag to be able to accept an array of values

### DIFF
--- a/core/helpers/mvc_form_helper.php
+++ b/core/helpers/mvc_form_helper.php
@@ -258,7 +258,12 @@ class MvcFormHelper extends MvcHelper {
                 $key = $value->__id;
                 $value = $value->__name;
             }
-            $selected_attribute = $options['value'] == $key ? ' selected="selected"' : '';
+            if (is_array($options['value'])) {
+                $selected_attribute = in_array($key, $options['value']) ? ' selected="selected"' : '';
+            } else {
+                $selected_attribute = $options['value'] == $key ? ' selected="selected"' : '';
+            }
+
             $html .= '<option value="'.$this->esc_attr($key).'"'.$selected_attribute.'>'.$value.'</option>';
         }
         $html .= '</select>';


### PR DESCRIPTION
It's a small bug, but still forced me to create my own helper to display has_many and HABTM selectboxes. 
My fix enables <select> form input with 'multiple' attribute to actually work.