### PR TITLE
Fix null type comparison issue when updating data

### DIFF
--- a/core/models/mvc_database_adapter.php
+++ b/core/models/mvc_database_adapter.php
@@ -163,12 +163,15 @@ class MvcDatabaseAdapter {
     public function get_set_sql($data) {
         $clauses = array();
         foreach ($data as $key => $value) {
-            if ($value == null) {
+            if ($value === null) {
                 $clauses[] = $key.' = NULL';
+            } elseif ($value === false) {
+                $clauses[] = $key.' = FALSE';
+            } elseif ($value === true) {
+                $clauses[] = $key.' = TRUE';
+            } else if (is_string($value) || is_numeric($value)) {
+                $clauses[] = $key.' = "' . $this->escape($value) . '"';
             }
-            else if (is_string($value) || is_numeric($value)) {
-                $clauses[] = $key . ' = "' . $this->escape($value) . '"';
-            }            
         }
         $sql = implode(', ', $clauses);
         return $sql;


### PR DESCRIPTION
When updating data, falsy values were saved as `NULL` due to the use of `==` instead of `===`. 

My changes are modeled after [this fix](https://github.com/tombenner/wp-mvc/pull/154), which addresses the same issue when inserting data.