### PR TITLE
Only start session in admin

### DIFF
--- a/core/controllers/mvc_controller.php
+++ b/core/controllers/mvc_controller.php
@@ -14,8 +14,8 @@ class MvcController {
     
     function __construct() {
 
-        // Necessary for flash()-related functionality
-        if (session_id() == '' && !headers_sent()) {
+        // Necessary for flash()-related functionality in the admin area only
+        if (is_admin() && session_id() == '' && !headers_sent()) {
             session_start();
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: tombenner, robertpeake
 Tags: mvc, framework, model, view, controller, development, plugin
 Requires at least: 3.0
-Tested up to: 4.7
-Stable tag: 1.3.11
+Tested up to: 4.9
+Stable tag: 1.3.12
 
 WP MVC is a full-fledged MVC framework, similar to CakePHP and Rails, that developers can use inside of WordPress.
 
@@ -70,6 +70,12 @@ If there's functionality that you'd like to use that isn't implemented in the ex
 5. The code of the "admin/add" view in the previous screenshot. Forms can be easily created using the form helper, which includes an `input()` method that automatically determines the data type of the field and shows an appropriate input tag. Methods for most types of inputs (textareas, hidden inputs, select tags, checkboxes, etc) are also available, as are association-related input methods like `belongs_to_dropdown()` and `has_many_dropdown()`.
 
 == Changelog ==
+
+= 1.3.12 =
+
+ * Fix null type comparison issue when updating data
+ * Only start session in admin
+ * Fixed select tag to be able to accept an array of values
 
 = 1.3.11 =
 

--- a/wp_mvc.php
+++ b/wp_mvc.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/wp-mvc/
 Description: Sets up an MVC framework inside of WordPress.
 Author: Tom Benner
 Modifications: Robert Peake, AR-General, Jonathan Gruber, Linda Furstenberger, Jordan Enev, Alastair, Chris Snyder, Fred Isaacs, Ceelo, Dangerous Dan, Eric Maziade, Fantasy1125, Glade, Derrick Hammer, Sam Wilson, Damiano Porta, Juuso Leinonen, David Eugene Pratt, David Lundgren, Victor Albert, Simon vom Eyser, Alvin Bunk, Jeffrey Fisher, Sergio Guzman, aleextra, Michał Krawczyk, mikehike123
-Version: 1.3.11
+Version: 1.3.12
 Text Domain: wpmvc
 Domain Path: /core/languages
 Author URI: https://github.com/tombenner


### PR DESCRIPTION
This will prevent front-end session cookies being generated on the user front-end, which can break caching.