### PR TITLE
new method to validate all fields at once and return errors in array

### DIFF
--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -500,10 +500,13 @@ class MvcModel {
             }
         }
     }
-    
+
     protected function validate_data($data) {
         if($this->validation_mode == 'all'){
             return $this->validate_all_data($data);
+        }
+        if(!is_null($this->validation_error)){
+            return $this->validation_error;
         }
         $rules = $this->validate;
         if (!empty($rules)) {
@@ -536,13 +539,25 @@ class MvcModel {
                 }
             }
             if (!empty($error_arr)) {
-                $this->validation_error = $error_arr;
+                $this->validation_error = array_merge($this->validation_error,$error_arr);
                 $this->validation_error_html = '';
                 $this->invalid_data = $data;
                 return $error_arr;
             }
         }
         return true;
+    }
+
+    protected function invalidate( $data, $field, $message ){
+        if($this->validation_mode == 'all'){
+            $this->validation_error[] = new MvcDataValidationError($field, $message);
+            $this->validation_error_html = '';
+        }else{
+            $this->validation_error = new MvcDataValidationError($field, $message);
+            $this->validation_error_html = $this->validation_error->get_html();
+        }
+
+        $this->invalid_data = $data;
     }
     
     protected function process_objects($objects, $options=array()) {

--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -539,11 +539,12 @@ class MvcModel {
                 }
             }
             if (!empty($error_arr)) {
-                $this->validation_error = array_merge($this->validation_error,$error_arr);
+                $this->validation_error = is_null($this->validation_error) ? $error_arr : array_merge($this->validation_error,$error_arr);
                 $this->validation_error_html = '';
                 $this->invalid_data = $data;
                 return $error_arr;
             }
+
         }
         return true;
     }

--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -13,6 +13,7 @@ class MvcModel {
     public $properties = null;
     public $validation_error = null;
     public $validation_error_html = null;
+    public $validation_mode = 'single';
     public $schema = null;
     public $wp_post = null;
     private $data_validator = null;
@@ -501,6 +502,9 @@ class MvcModel {
     }
     
     protected function validate_data($data) {
+        if($this->validation_mode == 'all'){
+            return $this->validate_all_data($data);
+        }
         $rules = $this->validate;
         if (!empty($rules)) {
             foreach ($rules as $field => $rule) {
@@ -513,6 +517,29 @@ class MvcModel {
                         return $valid;
                     }
                 }
+            }
+        }
+        return true;
+    }
+
+    protected function validate_all_data($data)
+    {
+        $rules = $this->validate;
+        if (!empty($rules)) {
+            $error_arr = array();
+            foreach ($rules as $field => $rule) {
+                if (isset($data[$field])) {
+                    $valid = $this->data_validator->validate($field, $data[$field], $rule);
+                    if ($valid !== true) {
+                        $error_arr[] = $valid;
+                    }
+                }
+            }
+            if (!empty($error_arr)) {
+                $this->validation_error = $error_arr;
+                $this->validation_error_html = '';
+                $this->invalid_data = $data;
+                return $error_arr;
             }
         }
         return true;

--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -538,7 +538,7 @@ class MvcModel {
                     }
                 }
             }
-            if (!empty($error_arr)) {
+            if (!empty($error_arr) || !is_null($this->validation_error)) {
                 $this->validation_error = is_null($this->validation_error) ? $error_arr : array_merge($this->validation_error,$error_arr);
                 $this->validation_error_html = '';
                 $this->invalid_data = $data;


### PR DESCRIPTION
new method
`validate_all_data`
 for mvc_model 

and new model field
`public $validation_mode = 'single';`

all this to be able to validate all fields at once, get error array in controller with
'$this->model->validation_error;'
an do whatever you want with this array.