### PR TITLE
Dl/theme support for view render

### DIFF
--- a/core/controllers/mvc_controller.php
+++ b/core/controllers/mvc_controller.php
@@ -259,10 +259,10 @@ class MvcController {
     protected function include_view($path, $view_vars=array()) {
         extract($view_vars);
         $path = preg_replace('/^admin_([^\/]+)/', 'admin/$1', $path);
-        $filepath = $this->file_includer->find_first_app_file_or_core_file('views/'.$path.'.php');
+        $filepath = $this->file_includer->find_theme_or_view_file($path);
         if (!$filepath) {
             $path = preg_replace('/admin\/(?!layouts)([\w_]+)/', 'admin', $path);
-            $filepath = $this->file_includer->find_first_app_file_or_core_file('views/'.$path.'.php');
+            $filepath = $this->file_includer->find_theme_or_view_file($path);
             if (!$filepath) {
                 MvcError::warning('View "'.$path.'" not found.');
             }

--- a/core/mvc_file_includer.php
+++ b/core/mvc_file_includer.php
@@ -4,10 +4,12 @@ class MvcFileIncluder {
 
     private $core_path = '';
     private $plugin_paths = array();
+    private $theme_path = '';
 
     function __construct() {
         $this->core_path = MVC_CORE_PATH;
         $this->plugin_app_paths = MvcConfiguration::get('PluginAppPaths');
+        $this->theme_path = get_stylesheet_directory();
     }
 
     public function find_theme_or_view_file($filepath)

--- a/core/mvc_file_includer.php
+++ b/core/mvc_file_includer.php
@@ -9,7 +9,18 @@ class MvcFileIncluder {
         $this->core_path = MVC_CORE_PATH;
         $this->plugin_app_paths = MvcConfiguration::get('PluginAppPaths');
     }
-    
+
+    public function find_theme_or_view_file($filepath)
+    {
+        foreach(MvcConfiguration::get('Plugins') as $plugin) {
+            if (file_exists($this->theme_path."/$plugin/$filepath.php")) {
+                return $this->theme_path."/$plugin/$filepath.php";
+            }
+        }
+
+        return $this->find_first_app_file_or_core_file("views/$filepath.php");
+    }
+
     public function find_first_app_file_or_core_file($filepath) {
         foreach ($this->plugin_app_paths as $plugin_app_path) {
             if (file_exists($plugin_app_path.$filepath)) {


### PR DESCRIPTION
This allows the views to be overridden by the theme.

The order of searching is now going to search the theme for each defined plugin:
- `get_stylesheet_directory()/$plugin/$filepath.php`
- `views/$filepath.php`