### PR TITLE
Cache 'DESCRIBE <table>' database queries

### DIFF
--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -19,6 +19,7 @@ class MvcModel {
     private $data_validator = null;
     protected $db_adapter = null;
     private $wp_post_adapter = null;
+    protected static $describe_cache = [];
     
     function __construct() {
         
@@ -672,10 +673,14 @@ class MvcModel {
     }
     
     protected function init_schema() {
-        $sql = '
-            DESCRIBE
-                '.$this->table_reference;
-        $results = $this->db_adapter->get_results($sql);
+        if ( isset( self::$describe_cache[ $this->table ] ) ) {
+            $results = self::$describe_cache[ $this->table ];
+        } else {
+            $results = $this->db_adapter->get_results(
+                "DESCRIBE {$this->table_reference}"
+            );
+            self::$describe_cache[ $this->table ] = $results;
+        }
         
         $schema = array();
         


### PR DESCRIPTION
Cache the result of `DESCRIBE <table>` database queries because they're
unlikely to change during a request lifecycle.