### PR TITLE
Make MvcFileIncluder also look for hyphenated file names

### DIFF
--- a/core/mvc_file_includer.php
+++ b/core/mvc_file_includer.php
@@ -14,13 +14,20 @@ class MvcFileIncluder {
 
     public function find_theme_or_view_file($filepath)
     {
-        foreach(MvcConfiguration::get('Plugins') as $plugin) {
-            if (file_exists($this->theme_path."/$plugin/$filepath.php")) {
-                return $this->theme_path."/$plugin/$filepath.php";
-            }
-        }
+		$possible_filepaths = array( $filepath, str_replace( '_', '-', $filepath ) );
+		foreach ( $possible_filepaths as $filepath ) {
+			foreach(MvcConfiguration::get('Plugins') as $plugin) {
+				if (file_exists($this->theme_path."/$plugin/$filepath.php")) {
+					return $this->theme_path."/$plugin/$filepath.php";
+				}
+			}
 
-        return $this->find_first_app_file_or_core_file("views/$filepath.php");
+			$app_or_cor_file = $this->find_first_app_file_or_core_file("views/$filepath.php");
+			if ( $app_or_cor_file ) {
+				return $app_or_cor_file;
+			}
+		}
+		return false;
     }
 
     public function find_first_app_file_or_core_file($filepath) {
@@ -37,7 +44,7 @@ class MvcFileIncluder {
         }
         return false;
     }
-    
+
     public function require_first_app_file_or_core_file($filepath) {
         if ($this->include_first_app_file($filepath)) {
             return true;
@@ -50,7 +57,7 @@ class MvcFileIncluder {
         }
         return false;
     }
-    
+
     public function require_all_app_files_or_core_file($filepath) {
         if ($this->include_all_app_files($filepath)) {
             return true;
@@ -63,7 +70,7 @@ class MvcFileIncluder {
         }
         return false;
     }
-    
+
     public function require_core_file($filepath) {
         if ($this->include_core_file('pluggable/'.$filepath)) {
             return true;
@@ -73,7 +80,7 @@ class MvcFileIncluder {
         }
         return false;
     }
-    
+
     public function require_first_app_file($filepath) {
         foreach ($this->plugin_app_paths as $plugin_app_path) {
             if ($this->include_file($plugin_app_path.$filepath)) {
@@ -82,7 +89,7 @@ class MvcFileIncluder {
         }
         MvcError::fatal('The file "'.$filepath.'" couldn\'t be found in any apps.');
     }
-    
+
     public function include_all_app_files($filepath) {
         $included = false;
         foreach ($this->plugin_app_paths as $plugin_app_path) {
@@ -92,11 +99,11 @@ class MvcFileIncluder {
         }
         return $included;
     }
-    
+
     public function include_core_file($filepath) {
         return $this->include_file($this->core_path.$filepath);
     }
-    
+
     public function include_first_app_file($filepath) {
         foreach ($this->plugin_app_paths as $plugin_app_path) {
             if ($this->include_file($plugin_app_path.$filepath)) {
@@ -105,7 +112,7 @@ class MvcFileIncluder {
         }
         return false;
     }
-    
+
     public function include_first_app_file_or_core_file($filepath) {
         foreach ($this->plugin_app_paths as $plugin_app_path) {
             if ($this->include_file($plugin_app_path.$filepath)) {
@@ -119,7 +126,7 @@ class MvcFileIncluder {
         }
         return true;
     }
-    
+
     public function require_all_app_files($filepath) {
         $included = false;
         foreach ($this->plugin_app_paths as $plugin_app_path) {
@@ -129,9 +136,9 @@ class MvcFileIncluder {
         }
         return $included;
     }
-    
+
     public function get_php_files_in_directory($directory, $options=array()) {
-        
+
         $filenames = array();
         if (is_dir($directory)) {
             if (isset($options['recursive'])) {
@@ -141,31 +148,31 @@ class MvcFileIncluder {
             }
             $filenames = array_filter($filenames, array($this, 'is_php_file'));
         }
-        
+
         return $filenames;
-    
+
     }
-    
+
     public function require_php_files_in_directory($directory, $options=array()) {
-    
+
         $filenames = $this->get_php_files_in_directory($directory);
         $filepaths = array();
-        
+
         foreach ($filenames as $filename) {
             $filepath = $directory.$filename;
             $filepaths[] = $filepath;
             $this->require_file($filepath);
         }
-        
+
         return $filenames;
-        
+
     }
-    
+
     private function require_file($filepath) {
         require_once $filepath;
         return true;
     }
-    
+
     private function include_file($filepath) {
         if (file_exists($filepath)) {
             $this->require_file($filepath);
@@ -173,16 +180,16 @@ class MvcFileIncluder {
         }
         return false;
     }
-    
+
     private function is_php_file($filename) {
         return preg_match('/.+\.php$/', $filename);
     }
-    
+
     private function scandir_recursive($directory) {
-    
+
         $file_tmp = glob($directory.'*', GLOB_MARK | GLOB_NOSORT);
         $files = array();
-        
+
         foreach ($file_tmp as $item){
             if (substr($item, -1) != DIRECTORY_SEPARATOR) {
                 $files[] = $item;
@@ -190,9 +197,9 @@ class MvcFileIncluder {
                 $files = array_merge($files, $this->scandir_recursive($item));
             }
         }
-    
+
         return $files;
-    
+
     }
 
 }


### PR DESCRIPTION
This make possible the use of file names separated by hyphens, without losing retrocompability. This way a developer could use `my_action.php` as well as `my-action.php`, meeting the [WordPress Coding Standards for file names](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#naming-conventions).