### PR TITLE
Error messages when $validation_mode = 'all'

### DIFF
--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -542,6 +542,11 @@ class MvcModel {
             if (!empty($error_arr) || !is_null($this->validation_error)) {
                 $this->validation_error = is_null($this->validation_error) ? $error_arr : array_merge($this->validation_error,$error_arr);
                 $this->validation_error_html = '';
+				if ( is_array($this->validation_error) && !empty($this->validation_error) ) {
+					foreach ( $this->validation_error as $error ) {
+						$this->validation_error_html .= $error->get_html();
+					}
+				}
                 $this->invalid_data = $data;
                 return $error_arr;
             }


### PR DESCRIPTION
When `$validation_mode = 'all'`, error messages are not displayed in admin notices area (just an empty box).
Looping through all `$this->validation_error` and append single error HTML html to `$this->validation_error_html`.

![wp-mvc](https://user-images.githubusercontent.com/47946188/54615629-b674cd00-4a5e-11e9-818c-78ee1ba7c853.jpg)
