### PR TITLE
Several changes

### DIFF
--- a/core/controllers/mvc_admin_controller.php
+++ b/core/controllers/mvc_admin_controller.php
@@ -52,7 +52,7 @@ class MvcAdminController extends MvcController {
                 }
             } else {
                 if ($this->model->save($this->params['data'])) {
-                    $this->flash('notice', __('Successfully saved!', 'wpvmc'));
+                    $this->flash('notice', __('Successfully saved!', 'wpmvc'));
                     $this->refresh();
                 } else {
                     $this->flash('error', $this->model->validation_error_html);
@@ -100,6 +100,7 @@ class MvcAdminController extends MvcController {
             'format' => '?page_num=%#%',
             'total' => $collection['total_pages'],
             'current' => $collection['page'],
+            'total_objects' => $collection['total_objects'],
             'add_args' => $params
         ));
     }

--- a/core/helpers/mvc_helper.php
+++ b/core/helpers/mvc_helper.php
@@ -169,13 +169,13 @@ class MvcHelper {
         foreach ($controller->default_columns as $key => $column) {
             $html .= $this->admin_header_cell(__($column['label'], $this->plugin_name));
         }
-        $html .= $this->admin_header_cell('');
+        $html .= $this->admin_header_cell('', ' wpmvc-actions');
         return '<tr>'.$html.'</tr>';
         
     }
     
-    public function admin_header_cell($label) {
-        return '<th scope="col" class="manage-column">'.$label.'</th>';
+    public function admin_header_cell($label, $class=null) {
+        return '<th scope="col" class="manage-column'. $class . '">'.$label.'</th>';
     }
     
     public function admin_table_cells($controller, $objects, $options = array()) {
@@ -229,7 +229,7 @@ class MvcHelper {
         }
 
         $html = implode(' | ', $links);
-        return '<td>'.$html.'</td>';
+        return '<td class="wpmvc-actions">'.$html.'</td>';
     }
     
     // To do: move this into an MvcUtilities class (?)

--- a/core/loaders/mvc_admin_loader.php
+++ b/core/loaders/mvc_admin_loader.php
@@ -261,7 +261,7 @@ class MvcAdminLoader extends MvcLoader {
             add_settings_section($section_key, '', array($instance, 'description'), $settings_key);
             register_setting($settings_key, $settings_key, array($instance, 'validate_fields'));
             foreach ($instance->settings as $setting_key => $setting) {
-                add_settings_field($setting_key, $setting['label'], array($instance, 'display_field_'.$setting_key), $settings_key, $section_key);
+                add_settings_field($setting_key, $setting['label'], array($instance, 'display_field_'.$setting_key), $settings_key, $section_key, $setting['args']);
             }
         }
     }

--- a/core/mvc_settings.php
+++ b/core/mvc_settings.php
@@ -9,7 +9,11 @@ class MvcSettings {
     
     function __construct() {
         $this->name = get_class($this);
-        $this->title = MvcInflector::titleize($this->name);
+        $this->plugin_name = MvcObjectRegistry::get_object('plugin_name');
+        if (! isset($this->plugin_name)) {
+            $this->plugin_name = '';
+        }
+        $this->title = __(MvcInflector::titleize($this->name), $this->plugin_name);
         $this->key = 'mvc_'.MvcInflector::underscore($this->name);
         $this->init_settings();
     }
@@ -23,7 +27,7 @@ class MvcSettings {
         echo '<form action="options.php" method="post">';
         settings_fields($this->key);
         do_settings_sections($this->key);
-        echo '<input name="Submit" type="submit" value="'.esc_attr('Save Changes').'" />';
+        echo '<input name="Submit" type="submit" value="'.esc_attr(__('Save Changes', 'wpmvc')).'" />';
         echo '</form>';
         echo '</div>';
     }
@@ -47,7 +51,8 @@ class MvcSettings {
             'id' => $setting['key'],
             'name' => $this->key.'['.$setting['key'].']',
             'type' => $setting['type'],
-            'value' => $input_value
+            'value' => $input_value,
+            'class' => 'regular-text',
         );
         if ($setting['type'] == 'checkbox' && $value) {
             $input_options['checked'] = 'checked';
@@ -59,7 +64,7 @@ class MvcSettings {
                 $input_options['options'] = $this->{$setting['options_method']}();
             }
         }
-        $html = MvcFormTagsHelper::input($setting_key, $input_options);
+        $html = MvcFormTagsHelper::input($setting_key, $input_options) . "\n";
         echo $html;
     }
     

--- a/core/pluggable/views/admin/index.php
+++ b/core/pluggable/views/admin/index.php
@@ -1,4 +1,4 @@
-<h2><?php echo MvcInflector::pluralize_titleize($model->name); ?></h2>
+<h2><?php _e(MvcInflector::pluralize_titleize($model->name), $this->helper->plugin_name); ?></h2>
 
 <form id="posts-filter" action="<?php echo MvcRouter::admin_url(); ?>" method="get">
 

--- a/wp_mvc.php
+++ b/wp_mvc.php
@@ -4,7 +4,6 @@ Plugin Name: WP MVC
 Plugin URI: http://wordpress.org/extend/plugins/wp-mvc/
 Description: Sets up an MVC framework inside of WordPress.
 Author: Tom Benner
-Modifications: Sergio Guzman
 Version: 1.3.7.2
 Text Domain: wpmvc
 Domain Path: /core/languages


### PR DESCRIPTION
Passed total_objects from collection to pagination, so one can show in a list (or table) how many items were found.

Modified admin_header_cell to append a class to "manage-column", in this case I chose " wpmvc-actions" (watch the leading whitespace so the append to manage-column works as 2 separate classes, basically I needed this to have this in a print.css, to hide the actions column in a table: 

`.wpmvc-actions {
    display: none;
}`

In the call to add_settings_field I added $setting['args'] in this case we can pass additional arguments to the settings, I use it to pass label_for so the display of settings is cleaner example:

```
class AppointmentSettings extends MvcSettings {
    var $settings = array(
....
       'notification_host' => array(
            'type' => 'text',
            'args' => array('label_for' => 'notification_host'),
            'label' => 'Email server',
        )
);
}
```

Other changes are basically in translation and testing with isset before using.

$this->helper->plugin_name in **pluggable/views/admin/index.php** allows me to use my own plugin's name for translation purposes in admin views instead or using wpmvc.

For mvc_settings.php getting plugin_name from the registry I took similar code from **core/helpers/mvc_helper.php**


Ps. These changes are from 2017 but wanted to send a PR, I believe they won't break anything hopefully 