### PR TITLE
Remove "dist" section in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,6 @@
     "name": "tombenner/wp-mvc",
     "description": "An MVC framework for WordPress http://wpmvc.org",
     "type": "wordpress-plugin",
-    "dist": {
-      "url": "https://github.com/tombenner/wp-mvc.git",
-      "type": "git"
-    },
     "license": "GPL",
     "authors": [
         {


### PR DESCRIPTION
This section provokes the error:

```[LogicException]
  Downloader "Composer\Downloader\GitDownloader" is a source type downloader and can not be used to download dist for package tombenner/wp-mvc-9999999-dev
```

