### PR TITLE
Fix bug with belong_to_dropdown form element name

### DIFF
--- a/core/helpers/mvc_form_helper.php
+++ b/core/helpers/mvc_form_helper.php
@@ -362,7 +362,7 @@ class MvcFormHelper extends MvcHelper {
 
         $defaults = array(
             'id' => $this->model_name.'_'.$model_name.'_select',
-            'name' => 'data['.$this->model_name.']['.$foreign_key.']',
+            'name' => $foreign_key,
             'label' => __(MvcInflector::titleize($model_name), $this->plugin_name),
             'value' => $value,
             'options' => $select_options,


### PR DESCRIPTION
After last code merge in helpers was added wrap function "input_name" for "name" attribute to "select_tag" of MvcFormHelper class.
And now method "belongs_to_dropdown" of same helper class wrap field name with "data['model name']['field name']" and in "select_tag" it wrapped twice - as result field have wrong name and not save its value in DB. So I removed wrap in first method and now its work as expected.

Or alternatively was proposed other fix in comment to problematic commit https://github.com/tombenner/wp-mvc/commit/68c2504b0f47fed6f23f9365fd5c7f25de51bdcb#commitcomment-47203595