### PR TITLE
Fix PHP 8.2 dynamic property deprecations

### DIFF
--- a/core/controllers/mvc_controller.php
+++ b/core/controllers/mvc_controller.php
@@ -11,6 +11,7 @@ class MvcController {
     public $params = null;
     public $view_rendered = false;
     public $view_vars = array();
+    private $dynamic = array();
     
     function __construct() {
 
@@ -22,6 +23,22 @@ class MvcController {
         $this->set_meta();
         $this->file_includer = new MvcFileIncluder();
     
+    }
+
+    public function __get($name) {
+        return isset($this->dynamic[$name]) ? $this->dynamic[$name] : null;
+    }
+
+    public function __set($name, $value) {
+        $this->dynamic[$name] = $value;
+    }
+
+    public function __isset($name) {
+        return isset($this->dynamic[$name]);
+    }
+
+    public function __unset($name) {
+        unset($this->dynamic[$name]);
     }
     
     public function init() {

--- a/core/helpers/mvc_helper.php
+++ b/core/helpers/mvc_helper.php
@@ -3,6 +3,7 @@
 class MvcHelper {
 
     protected $file_includer = null;
+    private $dynamic = array();
     
     function __construct() {
         $this->file_includer = new MvcFileIncluder();
@@ -11,6 +12,22 @@ class MvcHelper {
         if (! isset($this->plugin_name)) {
             $this->plugin_name = '';
         }
+    }
+
+    public function __get($name) {
+        return isset($this->dynamic[$name]) ? $this->dynamic[$name] : null;
+    }
+
+    public function __set($name, $value) {
+        $this->dynamic[$name] = $value;
+    }
+
+    public function __isset($name) {
+        return isset($this->dynamic[$name]);
+    }
+
+    public function __unset($name) {
+        unset($this->dynamic[$name]);
     }
     
     public function init() {

--- a/core/helpers/mvc_html_helper.php
+++ b/core/helpers/mvc_html_helper.php
@@ -72,10 +72,8 @@ class MvcHtmlHelper extends MvcHelper {
     }
 
     public function __call($method, $args) {
-        if (property_exists($this, $method)) {
-            if (is_callable($this->$method)) {
-                return call_user_func_array($this->$method, $args);
-            }
+        if (isset($this->$method) && is_callable($this->$method)) {
+            return call_user_func_array($this->$method, $args);
         }
     }
 

--- a/core/loaders/mvc_admin_loader.php
+++ b/core/loaders/mvc_admin_loader.php
@@ -18,7 +18,7 @@ class MvcAdminLoader extends MvcLoader {
         global $plugin_page;
         
         // If the beginning of $plugin_page isn't 'mvc_', then this isn't a WP MVC-generated page
-        if (substr($plugin_page, 0, 4) != 'mvc_') {
+        if (empty($plugin_page) || substr($plugin_page, 0, 4) != 'mvc_') {
             return false;
         }
         

--- a/core/loaders/mvc_loader.php
+++ b/core/loaders/mvc_loader.php
@@ -10,6 +10,8 @@ abstract class MvcLoader {
     protected $model_names = array();
     protected $public_controller_names = array();
     protected $query_vars = array();
+    protected $settings_names = array();
+    private $dynamic = array();
 
     function __construct() {
     
@@ -31,10 +33,26 @@ abstract class MvcLoader {
         $this->dispatcher = new MvcDispatcher();
 
         $this->plugin_name = MvcObjectRegistry::get_object('plugin_name');
-        if (! isset($this->plugin_name)) {
+        if (!isset($this->plugin_name)) {
             $this->plugin_name = '';
         }
 
+    }
+
+    public function __get($name) {
+        return isset($this->dynamic[$name]) ? $this->dynamic[$name] : null;
+    }
+
+    public function __set($name, $value) {
+        $this->dynamic[$name] = $value;
+    }
+
+    public function __isset($name) {
+        return isset($this->dynamic[$name]);
+    }
+
+    public function __unset($name) {
+        unset($this->dynamic[$name]);
     }
 
     

--- a/core/models/mvc_database_adapter.php
+++ b/core/models/mvc_database_adapter.php
@@ -4,9 +4,26 @@ class MvcDatabaseAdapter {
 
     public $db;
     public $defaults;
+    private $dynamic = array();
 
     function __construct() {
         $this->db = new MvcDatabase();
+    }
+
+    public function __get($name) {
+        return isset($this->dynamic[$name]) ? $this->dynamic[$name] : null;
+    }
+
+    public function __set($name, $value) {
+        $this->dynamic[$name] = $value;
+    }
+
+    public function __isset($name) {
+        return isset($this->dynamic[$name]);
+    }
+
+    public function __unset($name) {
+        unset($this->dynamic[$name]);
     }
     
     public function escape($value) {

--- a/core/models/mvc_model.php
+++ b/core/models/mvc_model.php
@@ -20,6 +20,7 @@ class MvcModel {
     protected $db_adapter = null;
     private $wp_post_adapter = null;
     protected static $describe_cache = array();
+    private $dynamic = array();
 
     function __construct() {
         
@@ -74,6 +75,22 @@ class MvcModel {
         $this->init_associations();
         $this->init_properties();
     
+    }
+
+    public function __get($name) {
+        return isset($this->dynamic[$name]) ? $this->dynamic[$name] : null;
+    }
+
+    public function __set($name, $value) {
+        $this->dynamic[$name] = $value;
+    }
+
+    public function __isset($name) {
+        return isset($this->dynamic[$name]);
+    }
+
+    public function __unset($name) {
+        unset($this->dynamic[$name]);
     }
     
     public function new_object($data) {

--- a/core/models/mvc_model_object.php
+++ b/core/models/mvc_model_object.php
@@ -4,6 +4,7 @@ class MvcModelObject {
     
     public $__model_name = null;
     private $__settings = null;
+    private $dynamic = array();
     
     function __construct($model) {
         $this->__settings = array();
@@ -16,10 +17,15 @@ class MvcModelObject {
     }
     
     public function to_array() {
-        return get_object_vars($this);
+        $vars = get_object_vars($this);
+        unset($vars['dynamic']);
+        return array_merge($this->dynamic, $vars);
     }
     
     public function __get($property_name) {
+        if (isset($this->dynamic[$property_name])) {
+            return $this->dynamic[$property_name];
+        }
         if (!empty($this->__settings['properties'][$property_name])) {
             $property = $this->__settings['properties'][$property_name];
             if ($property['type'] == 'association') {
@@ -44,6 +50,18 @@ class MvcModelObject {
         }
         $class = empty($this->__model_name) ? 'MvcModelObject' : $this->__model_name;
         MvcError::warning('Undefined property: '.$class.'::'.$property_name.'.');
+    }
+
+    public function __set($name, $value) {
+        $this->dynamic[$name] = $value;
+    }
+
+    public function __isset($name) {
+        return isset($this->dynamic[$name]);
+    }
+
+    public function __unset($name) {
+        unset($this->dynamic[$name]);
     }
     
     private function get_associated_objects($association) {

--- a/core/models/mvc_model_object.php
+++ b/core/models/mvc_model_object.php
@@ -99,5 +99,3 @@ class MvcModelObject {
     }
     
 }
-
-?>

--- a/core/mvc_configuration.php
+++ b/core/mvc_configuration.php
@@ -2,6 +2,8 @@
 
 class MvcConfiguration {
 
+    private $config = array();
+
     static function &get_instance($boot = true) {
         static $instance = array();
         
@@ -22,11 +24,14 @@ class MvcConfiguration {
 
         foreach ($config as $name => $value) {
             if (strpos($name, '.') === false) {
-                $_this->{$name} = $value;
+                $_this->config[$name] = $value;
             } else {
                 $names = explode('.', $name, 2);
                 if (count($names) == 2) {
-                    $_this->{$names[0]}[$names[1]] = $value;
+                    if (!isset($_this->config[$names[0]]) || !is_array($_this->config[$names[0]])) {
+                        $_this->config[$names[0]] = array();
+                    }
+                    $_this->config[$names[0]][$names[1]] = $value;
                 }
             }
         }
@@ -42,10 +47,10 @@ class MvcConfiguration {
         }
 
         foreach ($config as $name => $value) {
-            if (empty($_this->{$name})) {
-                $_this->{$name} = $value;
+            if (empty($_this->config[$name])) {
+                $_this->config[$name] = $value;
             } else {
-                $_this->{$name} = array_merge($_this->{$name}, $value);
+                $_this->config[$name] = array_merge($_this->config[$name], $value);
             }
         }
         
@@ -59,18 +64,30 @@ class MvcConfiguration {
             $names = explode('.', $config, 2);
             $config = $names[0];
         }
-        if (!isset($_this->{$config})) {
+        if (!isset($_this->config[$config])) {
             return null;
         }
         if (!isset($names[1])) {
-            return $_this->{$config};
+            return $_this->config[$config];
         }
         if (count($names) == 2) {
-            if (isset($_this->{$config}[$names[1]])) {
-                return $_this->{$config}[$names[1]];
+            if (isset($_this->config[$config][$names[1]])) {
+                return $_this->config[$config][$names[1]];
             }
         }
         return null;
+    }
+
+    public function __get($name) {
+        return isset($this->config[$name]) ? $this->config[$name] : null;
+    }
+
+    public function __set($name, $value) {
+        $this->config[$name] = $value;
+    }
+
+    public function __isset($name) {
+        return isset($this->config[$name]);
     }
 
 }

--- a/core/mvc_dispatcher.php
+++ b/core/mvc_dispatcher.php
@@ -2,6 +2,8 @@
 
 class MvcDispatcher {
 
+    private $dynamic = array();
+
     static function dispatch($options=array()) {
         
         $controller_name = $options['controller'];
@@ -92,6 +94,22 @@ class MvcDispatcher {
             $function = $this->$method;
             $function();
         }
+    }
+
+    public function __get($name) {
+        return isset($this->dynamic[$name]) ? $this->dynamic[$name] : null;
+    }
+
+    public function __set($name, $value) {
+        $this->dynamic[$name] = $value;
+    }
+
+    public function __isset($name) {
+        return isset($this->dynamic[$name]);
+    }
+
+    public function __unset($name) {
+        unset($this->dynamic[$name]);
     }
 
 }

--- a/core/mvc_file_includer.php
+++ b/core/mvc_file_includer.php
@@ -5,11 +5,28 @@ class MvcFileIncluder {
     private $core_path = '';
     private $plugin_paths = array();
     private $theme_path = '';
+    private $dynamic = array();
 
     function __construct() {
         $this->core_path = MVC_CORE_PATH;
         $this->plugin_app_paths = MvcConfiguration::get('PluginAppPaths');
         $this->theme_path = get_stylesheet_directory();
+    }
+
+    public function __get($name) {
+        return isset($this->dynamic[$name]) ? $this->dynamic[$name] : null;
+    }
+
+    public function __set($name, $value) {
+        $this->dynamic[$name] = $value;
+    }
+
+    public function __isset($name) {
+        return isset($this->dynamic[$name]);
+    }
+
+    public function __unset($name) {
+        unset($this->dynamic[$name]);
     }
 
     public function find_theme_or_view_file($filepath)

--- a/core/shells/mvc_shell.php
+++ b/core/shells/mvc_shell.php
@@ -4,6 +4,7 @@ class MvcShell {
 
     protected $core_path = '';
     protected $file_includer = null;
+    private $dynamic = array();
 
     function __construct($args=array()) {
     
@@ -15,6 +16,22 @@ class MvcShell {
         
         $this->init($args);
     
+    }
+
+    public function __get($name) {
+        return isset($this->dynamic[$name]) ? $this->dynamic[$name] : null;
+    }
+
+    public function __set($name, $value) {
+        $this->dynamic[$name] = $value;
+    }
+
+    public function __isset($name) {
+        return isset($this->dynamic[$name]);
+    }
+
+    public function __unset($name) {
+        unset($this->dynamic[$name]);
     }
     
     /**

--- a/core/shells/mvc_shell_dispatcher.php
+++ b/core/shells/mvc_shell_dispatcher.php
@@ -2,6 +2,8 @@
 
 class MvcShellDispatcher {
 
+    private $dynamic = array();
+
     function __construct($args) {
     
         $this->file_includer = new MvcFileIncluder();
@@ -10,6 +12,22 @@ class MvcShellDispatcher {
         
         $this->dispatch($args);
     
+    }
+
+    public function __get($name) {
+        return isset($this->dynamic[$name]) ? $this->dynamic[$name] : null;
+    }
+
+    public function __set($name, $value) {
+        $this->dynamic[$name] = $value;
+    }
+
+    public function __isset($name) {
+        return isset($this->dynamic[$name]);
+    }
+
+    public function __unset($name) {
+        unset($this->dynamic[$name]);
     }
     
     private function dispatch($args) {

--- a/wp_mvc.php
+++ b/wp_mvc.php
@@ -4,7 +4,7 @@ Plugin Name: WP MVC
 Plugin URI: http://wordpress.org/extend/plugins/wp-mvc/
 Description: Sets up an MVC framework inside of WordPress.
 Author: Tom Benner
-Modifications: Robert Peake, AR-General, Jonathan Gruber, Linda Furstenberger, Jordan Enev, Alastair, Chris Snyder, Fred Isaacs, Ceelo, Dangerous Dan, Eric Maziade, Fantasy1125, Glade, Derrick Hammer, Sam Wilson, Damiano Porta, Juuso Leinonen, David Eugene Pratt, David Lundgren, Victor Albert, Simon vom Eyser, Alvin Bunk, Jeffrey Fisher, Sergio Guzman, aleextra, Michał Krawczyk, mikehike123, polcodemichalkrawczyk, ptrkcsk, felipeelia, dlundgren, akamadr, gumster, konafet
+Modifications: Robert Peake, AR-General, Jonathan Gruber, Linda Furstenberger, Jordan Enev, Alastair, Chris Snyder, Fred Isaacs, Ceelo, Dangerous Dan, Eric Maziade, Fantasy1125, Glade, Derrick Hammer, Sam Wilson, Damiano Porta, Juuso Leinonen, David Eugene Pratt, David Lundgren, Victor Albert, Simon vom Eyser, Alvin Bunk, Jeffrey Fisher, Sergio Guzman, aleextra, Michał Krawczyk, mikehike123, polcodemichalkrawczyk, ptrkcsk, felipeelia, dlundgren, akamadr, gumster, konafet, andrevabo
 Version: 1.3.21
 Text Domain: wpmvc
 Domain Path: /core/languages

--- a/wp_mvc.php
+++ b/wp_mvc.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/wp-mvc/
 Description: Sets up an MVC framework inside of WordPress.
 Author: Tom Benner
 Modifications: Robert Peake, AR-General, Jonathan Gruber, Linda Furstenberger, Jordan Enev, Alastair, Chris Snyder, Fred Isaacs, Ceelo, Dangerous Dan, Eric Maziade, Fantasy1125, Glade, Derrick Hammer, Sam Wilson, Damiano Porta, Juuso Leinonen, David Eugene Pratt, David Lundgren, Victor Albert, Simon vom Eyser, Alvin Bunk, Jeffrey Fisher, Sergio Guzman, aleextra, Michał Krawczyk, mikehike123, polcodemichalkrawczyk, ptrkcsk, felipeelia, dlundgren, akamadr, gumster, konafet
-Version: 1.3.20
+Version: 1.3.21
 Text Domain: wpmvc
 Domain Path: /core/languages
 Author URI: https://github.com/tombenner


### PR DESCRIPTION
  - Adds magic property storage to core classes that assign dynamic properties at runtime.
  - Updates HTML helper dispatch to call injected closures safely.
  - Ensures model objects include dynamic fields in to_array().
  - Adds a guard for null $plugin_page to avoid calling substr with a null value in admin dispatch.